### PR TITLE
fix: add id-token permission for OIDC authentication

### DIFF
--- a/.github/workflows/submission-screen.yml
+++ b/.github/workflows/submission-screen.yml
@@ -12,6 +12,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      id-token: write
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary
- Adds missing `id-token: write` permission to the submission screening workflow

The `claude-code-action` uses OIDC authentication which requires this permission.
Without it, the workflow fails with "Unable to get ACTIONS_ID_TOKEN_REQUEST_URL env variable".

## Test plan
- [ ] Re-run the failing workflow on an existing submission PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)