### PR TITLE
fix: use direct_prompt instead of deprecated prompt input

### DIFF
--- a/.github/workflows/submission-screen.yml
+++ b/.github/workflows/submission-screen.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           allowed_tools: "Bash,Read,Grep,Glob,WebFetch"
-          prompt: |
+          direct_prompt: |
             You are screening a Dojo Game Jam submission PR for validity.
 
             ## Your Task


### PR DESCRIPTION
## Summary
- Renames `prompt` to `direct_prompt` in the submission screening workflow

The `claude-code-action@beta` expects `direct_prompt`, not `prompt`.
The workflow was failing with a warning about invalid input.

## Test plan
- [ ] Re-run the failing workflow on an existing submission PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)