### PR TITLE
fix: use explicit github_token for pull_request_target workflows

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,37 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/submission-screen.yml
+++ b/.github/workflows/submission-screen.yml
@@ -12,7 +12,6 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-      id-token: write
 
     steps:
       - name: Checkout PR head
@@ -24,7 +23,9 @@ jobs:
         uses: anthropics/claude-code-action@beta
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           allowed_tools: "Bash,Read,Grep,Glob,WebFetch"
+          mode: agent
           direct_prompt: |
             You are screening a Dojo Game Jam submission PR for validity.
 


### PR DESCRIPTION
## Summary
- Fix submission screening workflow by providing explicit `github_token` (OIDC doesn't work with `pull_request_target`)
- Add `mode: agent` for automation mode
- Add standard `claude.yml` workflow for interactive `@claude` mentions

## Test plan
- [ ] Re-run screening on PR #218 to verify fix
- [ ] Test `@claude` mention in an issue or PR comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)