### PR TITLE
fix: use pull_request event for screening workflow

### DIFF
--- a/.github/workflows/submission-screen.yml
+++ b/.github/workflows/submission-screen.yml
@@ -1,7 +1,7 @@
 name: Submission Screening
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, reopened]
     paths:
       - 'game-jam-*/*.md'


### PR DESCRIPTION
## Summary
- Fix the submission screening workflow to use `pull_request` instead of `pull_request_target`
- The `claude-code-action` does not support `pull_request_target` events

## Root Cause
The action fails with:
```
Unsupported event type: pull_request_target
```

The `claude-code-action` only supports: `issues`, `issue_comment`, `pull_request`, `pull_request_review`, `pull_request_review_comment`, `workflow_dispatch`, `repository_dispatch`, `schedule`, `workflow_run`.

## Test Plan
- [ ] Merge this PR
- [ ] Open a test PR that adds a file to `game-jam-*/*.md`
- [ ] Verify the screening workflow runs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)