### PR TITLE
fix: use 'prompt' instead of 'direct_prompt' for screening

### DIFF
--- a/.github/workflows/submission-screen.yml
+++ b/.github/workflows/submission-screen.yml
@@ -26,7 +26,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           allowed_tools: "Bash,Read,Grep,Glob,WebFetch"
           mode: agent
-          direct_prompt: |
+          prompt: |
             You are screening a Dojo Game Jam submission PR for validity.
 
             ## Your Task


### PR DESCRIPTION
## Summary
Fix the screening workflow to use the correct input name for claude-code-action.

## Root Cause
The previous commit changed `prompt` to `direct_prompt`, but the claude-code-action expects `prompt` as the input name. This caused the action to skip with "No trigger found" because `context.inputs.prompt` was empty.

## Test Plan
- [ ] Merge this PR
- [ ] The existing test PR #218 should re-trigger and run the screening

🤖 Generated with [Claude Code](https://claude.com/claude-code)