### PR TITLE
fix: use direct_prompt with tag mode for PR screening

### DIFF
--- a/.github/workflows/submission-screen.yml
+++ b/.github/workflows/submission-screen.yml
@@ -25,8 +25,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           allowed_tools: "Bash,Read,Grep,Glob,WebFetch"
-          mode: agent
-          prompt: |
+          direct_prompt: |
             You are screening a Dojo Game Jam submission PR for validity.
 
             ## Your Task


### PR DESCRIPTION
## Summary
Fix the screening workflow to properly trigger on pull_request events.

## Root Cause
In the `@beta` claude-code-action:
- `agent` mode only triggers for automation events (workflow_dispatch, schedule)
- `tag` mode with `direct_prompt` triggers on any event including pull_request

The workflow was using `mode: agent` which doesn't support pull_request events.

## Fix
- Removed `mode: agent` (uses default `tag` mode)
- Changed `prompt:` to `direct_prompt:`

The `direct_prompt` input causes tag mode to always trigger, bypassing the usual @claude mention check.

## Test Plan
- [ ] Merge this PR
- [ ] Open a new test PR with a submission file
- [ ] Verify the screening runs and posts a comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)