### PR TITLE
fix: only run submission screening for PRs with submission title

### DIFF
--- a/.github/workflows/submission-screen.yml
+++ b/.github/workflows/submission-screen.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   screen:
     runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.title, '[Project Submission]')
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
Adds a condition to the submission screening workflow to only run when the PR title contains '[Project Submission]', matching the submission template pattern.

This prevents the workflow from running on non-submission PRs that happen to modify game-jam files.