### PR TITLE
Allow feature submissions for existing games

### DIFF
--- a/.github/workflows/submission-screen.yml
+++ b/.github/workflows/submission-screen.yml
@@ -27,76 +27,11 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           allowed_tools: "Bash,Read,Grep,Glob,WebFetch"
           direct_prompt: |
-            You are screening a Dojo Game Jam submission PR for validity.
+            You are screening a Dojo Game Jam submission PR.
 
-            ## Your Task
+            Read SCREENING.md from the base branch (main) for the full screening process and follow it step by step.
+            Use `git show origin/main:SCREENING.md` to read it, rather than the copy on the PR branch.
 
-            1. **Find the submission file** in this PR (look in game-jam-*/*.md for new/modified files)
-            2. **Extract the GitHub repository URL** from the submission
-            3. **Parse jam dates** from README.md (look for "Coding begins... submissions are due" line)
-            4. **Clone and analyze the submitted repository:**
-               - Calculate % of commits during jam window
-               - Calculate % of lines changed during jam window
-               - Check for Dojo contracts (Cairo files with #[dojo::model], #[dojo::contract], #[dojo::event])
-               - Check for Dojo SDK usage in frontend (@dojoengine/* imports in JS/TS files)
-               - CRITICAL: Verify frontend actually USES the SDK (look for hook calls, not just imports)
-            5. **Post a PR comment** with your findings using gh cli
-
-            ## Screening Criteria
-
-            **Timeline (flag if violated):**
-            - At least 80% of commits should occur during jam window
-            - At least 80% of code changes should occur during jam window
-            - Repository created months before jam (3+) is suspicious
-
-            **Dojo Usage (flag if violated):**
-            - Must have Dojo contracts in Cairo files
-            - Frontend must import AND use Dojo SDK
-            - Having contracts but not using them in frontend = FAIL
-
-            ## Comment Format
-
-            Use this exact format for the PR comment (use gh pr comment):
-
-            ```
-            <!-- submission-screening-bot -->
-            ## 🤖 Automated Submission Screening
-
-            > [🚨 **FLAGGED FOR MANUAL REVIEW** 🚨 OR ✅ **Preliminary Check Passed**]
-
-            ### Summary
-            **Project:** [name]
-            **Repository:** [url]
-            **Verdict:** [APPROVED or FLAGGED]
-
-            [Your assessment paragraph]
-
-            ### Timeline Analysis
-            - First commit: [date]
-            - Commits during jam: X of Y (Z%)
-            - Lines changed during jam: Z%
-            [Assessment]
-
-            ### Dojo Usage
-            **Contracts:** [X models, Y systems, Z events]
-            **Frontend SDK:** [Found/Not found, actual usage detected?]
-            [Assessment]
-
-            ---
-            *Automated screening. A maintainer will perform final review.*
-            ```
-
-            ## Guidelines
-
-            - Be pragmatic and inclusive - flag only clear violations
-            - Concentrated commits (all in one day) are NORMAL - developers work locally
-            - Post-deadline commits for polish/deployment are OK
-            - Quality of work is not suspicious
-            - When in doubt, APPROVE
-
-            ## Environment
-
+            Environment:
             - PR number: ${{ github.event.pull_request.number }}
             - Repository: ${{ github.repository }}
-
-            Now analyze this submission and post your findings as a PR comment.

--- a/NOTES.md
+++ b/NOTES.md
@@ -1,0 +1,13 @@
+# Session Notes
+
+## Task
+Restructure screening process to:
+1. Auto-classify submissions as "Whole Game" vs "Feature" based on jam-window commit analysis
+2. Separate screening criteria (SCREENING.md) from workflow definition (submission-screen.yml)
+3. SCREENING.md serves dual purpose: human docs + agent instructions
+
+## Decisions Made
+- No changes to submission template - screening agent infers type from data
+- Whole Game = 90%+ of repo changed during jam window; Feature = <90%
+- Workflow prompt becomes a short bootstrap pointing to SCREENING.md
+- SCREENING.md restructured to be both human-readable and agent-executable

--- a/README.md
+++ b/README.md
@@ -102,10 +102,11 @@ Before submitting, make sure you have:
 When you submit a PR, an automated screening process checks your submission.
 Here's what we verify:
 
-1. **Dojo Usage**: Your project must meaningfully use the Dojo engine—Cairo contracts with `#[dojo::model]`, `#[dojo::contract]`, etc., and a frontend that actually integrates with them.
+1. **Dojo Usage**: Your project must meaningfully use the Dojo engine — Cairo contracts with `#[dojo::model]`, `#[dojo::contract]`, etc., and a frontend that actually integrates with them.
 2. **Timeline**: The bulk of your work should happen during the 72-hour jam window. Post-deadline polish and deployment commits are fine.
+3. **Classification**: Submissions are automatically classified as **Whole Game** (90%+ of the repo was built during the jam) or **Feature** (new features added to an existing game). Feature submissions are evaluated on their jam-window work, not the full repo history.
 
-Our philosophy is **pragmatic and inclusive**—we default to approving submissions and give benefit of the doubt.
+Our philosophy is **pragmatic and inclusive** — we default to approving submissions and give benefit of the doubt.
 See [SCREENING.md](./SCREENING.md) for full details.
 
 ## Judging

--- a/SCREENING.md
+++ b/SCREENING.md
@@ -1,291 +1,135 @@
-# Game Jam Submission Screening Guidelines
+# Game Jam Submission Screening
 
-This document outlines the process for screening Dojo Game Jam submissions to ensure they meet the minimum requirements for participation.
+This document defines the screening process for Dojo Game Jam submissions.
+It is used both as human-readable documentation and as instructions for the automated screening agent.
 
-## Overview
+## Philosophy
 
-The screening process is designed to be **pragmatic and inclusive** while maintaining the integrity of the game jam.
-The goal is to verify that submissions:
-
-1. Meaningfully use the Dojo game engine
-2. Were built during (or primarily for) the game jam period
-
-## Evaluation Criteria
-
-### 1. Meaningful Dojo Usage (REQUIRED)
-
-**PASS Criteria:**
-- Project uses Dojo game engine (Cairo smart contracts with Dojo framework)
-- Evidence of Dojo models, systems, and world interactions
-- Game logic goes beyond default "spawn and move" template
-- Proper Dojo dependencies in `Scarb.toml` or similar config
-
-**FAIL Criteria:**
-- No evidence of Dojo game engine usage
-- Only configuration files present, no actual implementation
-- Uses different "Dojo" framework (e.g., legacy Dojo Toolkit JavaScript library)
-- Basic template with minimal modifications
-- **Frontend does not integrate with Dojo contracts** (contracts exist but are unused/dead code)
-
-**How to Check:**
-```bash
-# Look for Dojo-specific files and patterns
-- Scarb.toml with dojo dependencies
-- Cairo files with #[dojo::contract], #[dojo::model], #[dojo::event]
-- World dispatcher usage (world.read_model(), world.write_model())
-- Dojo configuration files (dojo_*.toml)
-
-# CRITICAL: Verify frontend actually uses the contracts
-- Check if frontend imports Dojo SDK packages (@dojoengine/core, etc.)
-- Look for contract bindings being imported/used in frontend code
-- Verify game hooks/functions are actually called, not just generated
-- Check if deployed app actually interacts with Dojo world
-- Search for usage of generated hooks: grep -r "useGameData\|useMovePlayer" client/src
-```
-
-### 2. Jam Timeline (FLEXIBLE)
-
-**General Guidelines:**
-- Game jam typically runs Friday - Sunday (3 days)
-- Use AOE (Anywhere on Earth) timezone for start/end
-- Allow **reasonable flexibility** for final commits (polish, deployment, fixes)
-
-**PASS Criteria:**
-- Bulk of commits within jam window (start date - end date + 1 day)
-- Repository created during or shortly before jam
-- Concentrated commits are **acceptable** (developers often work locally first)
-- Post-deadline commits for bug fixes, deployment, polish are **acceptable**
-- Late submissions within ~24 hours are **acceptable** (benefit of doubt)
-
-**NEEDS REVIEW Criteria:**
-- Repository created weeks/months before jam
-- Significant commit activity before jam start date
-- May be allowed if submission is "new features for existing game" (check jam rules)
-
-**FAIL Criteria:**
-- Repository created many months before jam (3+ months)
-- No commits during jam window at all
-- Submission clearly predates jam announcement
-
-**How to Check:**
-```bash
-# Check repository creation date and commit timeline
-git log --all --format="%ai %s" --reverse | head -20  # First commits
-git log --all --format="%ai %s" | head -50            # Recent commits
-
-# Check for activity during jam window
-git log --since="YYYY-MM-DD" --until="YYYY-MM-DD" --oneline | wc -l
-```
+**Default to YES.**
+Game jams should be inclusive.
+Trust participants unless there's clear evidence of a violation.
+When in doubt, approve and let judges evaluate the game itself.
 
 ## Screening Process
 
-### Step 1: Automated Pre-Screening (GitHub Workflow)
+When a submission PR is opened, the screening agent performs the following steps.
 
-Create a GitHub workflow that runs when PRs are submitted:
+### Step 1: Find the Submission
 
-```yaml
-name: Submission Pre-Screen
-on:
-  pull_request:
-    paths:
-      - 'game-jam-*/*.md'
+Look in `game-jam-*/*.md` for new or modified files in the PR.
+Extract the GitHub repository URL from the submission file.
 
-jobs:
-  pre-screen:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
+### Step 2: Parse Jam Dates
 
-      - name: Extract Repository URL
-        id: extract
-        run: |
-          # Parse submission file for repository URL
-          REPO_URL=$(grep -oP 'https://github.com/[^\s]+' $SUBMISSION_FILE)
-          echo "repo_url=$REPO_URL" >> $GITHUB_OUTPUT
+Read `README.md` and find the line containing "Coding begins... submissions are due."
+Extract the start and end dates.
+Use AOE (Anywhere on Earth) timezone.
 
-      - name: Clone and Check Repository
-        run: |
-          git clone ${{ steps.extract.outputs.repo_url }} temp_repo
-          cd temp_repo
+### Step 3: Clone and Analyze
 
-          # Check for Dojo files
-          echo "=== Checking for Dojo Usage ==="
-          find . -name "Scarb.toml" -o -name "dojo*.toml"
-          grep -r "#\[dojo::" --include="*.cairo" || echo "WARNING: No Dojo annotations found"
+Clone the submitted repository and perform two analyses:
 
-          # Check commit timeline
-          echo "=== Commit Timeline ==="
-          echo "Repository created: $(git log --reverse --format="%ai" | head -1)"
-          echo "Latest commit: $(git log --format="%ai" | head -1)"
-          echo "Total commits: $(git log --oneline | wc -l)"
-          echo "Commits during jam window: $(git log --since="$JAM_START" --until="$JAM_END" --oneline | wc -l)"
+#### Submission Classification
 
-      - name: Comment on PR
-        uses: actions/github-script@v6
-        with:
-          script: |
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: '## Automated Pre-Screen Results\n\n' +
-                    'Please review the workflow logs for preliminary checks.\n' +
-                    'A human reviewer will complete the full evaluation.'
-            })
+Calculate what percentage of the repository's total codebase was changed during the jam window.
+Compare lines changed (additions + deletions) in jam-window commits vs total lines in the repo.
+Exclude lockfiles, generated bindings, and vendored assets from this calculation — they skew the ratio and don't reflect authored work.
+
+- **90% or more** = **Whole Game** submission (the game was built for the jam)
+- **Less than 90%** = **Feature** submission (new features added to an existing game)
+
+#### Jam-Window Commit Summary
+
+Identify all commits that fall within the jam window (with reasonable buffer: a day before, a day after).
+Produce a concise summary of what those commits contain.
+For Feature submissions, describe the changes in the context of the overall game.
+
+### Step 4: Evaluate
+
+#### Dojo Usage (required for both types)
+
+The project must meaningfully use the Dojo engine.
+
+**Pass:**
+- Cairo files with `#[dojo::model]`, `#[dojo::contract]`, or `#[dojo::event]`
+- Dojo dependencies in `Scarb.toml`
+- Frontend imports AND uses `@dojoengine/*` packages (not just generated/dead code)
+- World dispatcher usage (`world.read_model()`, `world.write_model()`)
+
+**Fail:**
+- No Dojo annotations in Cairo files
+- Frontend has contracts but doesn't integrate with them
+- Uses a different "Dojo" framework (e.g. the legacy Dojo Toolkit JS library)
+- Only config files, no actual implementation
+
+#### Timeline
+
+**For Whole Game submissions:**
+- At least 80% of commits should fall within the jam window
+- At least 80% of code changes should fall within the jam window
+- Flag if the repository was created 3+ months before the jam
+
+**For Feature submissions:**
+- The repository will pre-date the jam; this is expected and not suspicious
+- Focus on whether the described features were built during the jam window
+- At least 80% of the feature-related commits should fall within the jam window
+- A few commits before (setup) or after (polish, deployment) are fine
+
+### Step 5: Post Results
+
+Post a PR comment using `gh pr comment` with the following format:
+
+```
+<!-- submission-screening-bot -->
+## Automated Submission Screening
+
+> [VERDICT BANNER: see below]
+
+### Summary
+**Project:** [name]
+**Repository:** [url]
+**Classification:** [Whole Game / Feature]
+**Verdict:** [APPROVED / FLAGGED FOR MANUAL REVIEW]
+
+### Jam-Window Changes
+[Summary of what was built/changed during the jam window]
+[For Feature submissions: describe how these changes fit into the existing game]
+
+### Timeline Analysis
+- First commit: [date]
+- Jam-window commits: X of Y total (Z%)
+- Lines changed during jam: Z% of total repo
+[Assessment]
+
+### Dojo Usage
+**Contracts:** [X models, Y systems, Z events]
+**Frontend SDK:** [Found/Not found, actual usage detected?]
+[Assessment]
+
+---
+*Automated screening — a maintainer will perform final review.*
 ```
 
-### Step 2: Manual Review
+**Verdict banner:**
+- Use `✅ **Preliminary Check Passed**` when all checks pass
+- Use `🚨 **FLAGGED FOR MANUAL REVIEW** 🚨` when any check fails
 
-Use AI assistance (Claude Code) to perform detailed review:
+## Edge Cases
 
-```bash
-# Run review for all submissions
-claude-code "Review submissions in game-jam-X/submissions.md.
-For each repository:
-1. Check meaningful Dojo usage (not just config files)
-2. CRITICAL: Verify frontend actually integrates with/uses the Dojo contracts
-3. Check commit timeline relative to jam dates (Oct 31 - Nov 2, YYYY)
-4. Be pragmatic: concentrated commits are OK, late polish commits are OK
-5. Focus on: was this built FOR the jam?
+**All commits in one day** — APPROVE.
+Developers often work locally and push once.
 
-Create a formatted report with APPROVED/NEEDS_REVIEW/REJECTED for each."
-```
+**Commits 1-2 days after deadline** — APPROVE.
+Likely deployment, bug fixes, or polish.
 
-### Step 3: Generate Results
+**Very sophisticated project in 3 days** — APPROVE.
+Game jams produce impressive results. Don't penalize quality.
 
-Output format in `submissions-reviewed.md`:
+**Repository created before jam (Whole Game)** — FLAG.
+Ask submitter to clarify. Could be a Feature submission that should be reclassified.
 
-```markdown
-## ✅ APPROVED (X)
-- List of approved submissions with brief rationale
+**Contracts exist but frontend doesn't use them** — FLAG.
+Dead code doesn't count as Dojo usage.
 
-## ⚠️ NEEDS REVIEW (X)
-- List of submissions needing clarification
-- Specific questions to ask submitters
-
-## ❌ REJECTED (X)
-- List of rejected submissions with clear reasons
-```
-
-## Decision Guidelines
-
-### When to APPROVE:
-- ✅ Meaningful Dojo usage confirmed
-- ✅ Commits primarily during jam window
-- ✅ Any reasonable doubt → approve (inclusive approach)
-
-### When to flag for REVIEW:
-- ⚠️  Repository created before jam but with jam activity (could be "new features")
-- ⚠️  Concentrated commits that seem too complete (could be pre-existing)
-- ⚠️  Commits slightly outside window but otherwise legitimate
-
-### When to REJECT:
-- ❌ Not using Dojo game engine
-- ❌ Cannot verify Dojo usage at all
-- ❌ Repository clearly predates jam by months
-- ❌ Zero activity during jam window
-
-## Common Edge Cases
-
-### 1. "All commits in one day"
-**Decision**: APPROVE
-**Reason**: Developers often work locally and push once. This is normal.
-
-### 2. "Commits continue 1-2 days after deadline"
-**Decision**: APPROVE
-**Reason**: Likely deployment, bug fixes, polish. Core game was built during jam.
-
-### 3. "Repository created before jam"
-**Decision**: NEEDS REVIEW
-**Reason**: Could be "new features for existing game" (allowed per rules). Ask submitter to clarify scope.
-
-### 4. "Very sophisticated project in 3 days"
-**Decision**: APPROVE (unless other red flags)
-**Reason**: Game jams produce impressive results. Don't penalize quality.
-
-### 5. "Repository created after deadline"
-**Decision**: NEEDS REVIEW
-**Reason**: Could be migration from private repo. Contact submitter to verify.
-
-### 6. "Uses 'Dojo' but wrong framework"
-**Decision**: REJECT
-**Reason**: Must use Dojo game engine, not other frameworks with similar names.
-
-### 7. "Contracts exist but frontend doesn't use them"
-**Decision**: REJECT
-**Reason**: Having Dojo contracts in the repo doesn't make it a Dojo game if the frontend doesn't integrate with them. Check for actual usage of generated hooks/bindings in the application code, not just their existence. Dead code doesn't count.
-
-## Pragmatic Philosophy
-
-> **"Default to YES"** - If you're unsure, approve it. Game jams should be inclusive.
-
-- Trust participants unless there's clear evidence of violation
-- Concentrated commits are normal developer behavior
-- A few extra hours for deployment is fine
-- Quality of work is not suspicious - game jams produce amazing results
-- When in doubt, approve and let judges evaluate the game itself
-
-## Template for Future Jams
-
-```markdown
-# Game Jam X Screening
-
-**Jam Dates**: [Start Date] - [End Date] (AOE timezone)
-**Evaluation Window**: [Start Date] 00:00 AOE to [End Date + 1] 23:59 AOE
-**Screening Date**: [Date]
-
-## Criteria
-1. Meaningful Dojo game engine usage
-2. Built during/for the jam (pragmatic timeline enforcement)
-
-## Results
-- ✅ APPROVED: X submissions
-- ⚠️ NEEDS REVIEW: X submissions
-- ❌ REJECTED: X submissions
-
-[Detailed breakdown follows...]
-```
-
-## GitHub Workflow Implementation
-
-The automated screening workflow is implemented in `.github/workflows/submission-screen.yml`.
-It uses the `anthropics/claude-code-action` to have Claude directly analyze submissions and post results as PR comments.
-
-### Setup Instructions
-
-1. **Add the Anthropic API key** to your repository secrets:
-   - Go to Settings → Secrets and variables → Actions
-   - Add a new secret named `ANTHROPIC_API_KEY` with your API key
-
-2. **Update jam dates** in `README.md`:
-   - Claude parses jam dates from the README
-   - Format: "Coding begins Friday, October 31 at 00:00 **AOE**, and submissions are due on Sunday, November 2 at 23:59 **AOE**"
-
-3. **Workflow triggers automatically** when:
-   - A PR is opened targeting `game-jam-*/*.md` files
-   - A PR is updated (synchronize event)
-   - A PR is reopened
-
-### What Claude Checks
-
-1. **Timeline Analysis**:
-   - Percentage of commits during jam window (flags if <80%)
-   - Percentage of code changes during jam window (flags if <80%)
-   - Detects if repository was created months before jam
-
-2. **Dojo Usage Verification**:
-   - Checks for Dojo contracts (Cairo files with `#[dojo::model]`, `#[dojo::contract]`, `#[dojo::event]`)
-   - Checks for Dojo SDK usage in frontend (`@dojoengine/*` packages)
-   - **Critical check**: Verifies frontend actually uses the Dojo SDK (not just imports)
-
-### PR Comment Format
-
-Claude posts a comment with:
-- 🚨 **FLAGGED FOR MANUAL REVIEW** banner if issues found, or ✅ **Preliminary Check Passed**
-- Summary with project name, repository URL, and verdict
-- Timeline analysis with commit/line percentages
-- Dojo usage breakdown (contracts + frontend SDK)
-
-## Key Takeaway
-
-**Be pragmatic and inclusive.** The screening process should filter out clear violations (wrong framework, no Dojo usage, obviously pre-existing projects) while giving benefit of doubt to legitimate submissions with minor timing quirks or concentrated commit patterns. When uncertain, approve and let the judges evaluate the actual game.
+**Uses "Dojo" but wrong framework** — REJECT.
+Must use the Dojo game engine.


### PR DESCRIPTION
Restructure the submission screening process to properly handle feature submissions for existing games.

**Changes:**
- Screening logic separated from workflow YAML into SCREENING.md (easier iteration)
- Submissions auto-classified as Whole Game (90%+ built during jam) or Feature (<90%)
- Feature submissions evaluated on jam-window work only, not full repo history
- Workflow reads SCREENING.md from main branch to prevent tampering
- Excludes lockfiles and generated assets from classification ratio

**Benefits:**
- Existing-game submissions no longer flagged for old repository dates
- Clear criteria for what counts as substantive jam-window work
- Easier to iterate on screening rules without touching YAML

Fixes the screening process described in README rule: "New features for existing games are allowed, but must be clearly scoped and defined."