### PR TITLE
docs: add registration links for gj7 and gj8

### DIFF
--- a/gj7/README.md
+++ b/gj7/README.md
@@ -16,6 +16,8 @@ prize_pool: "$15,000"
 
 **Sponsors:** Starknet, StarkWare, Cartridge
 
+**Registration:** https://luma.com/ug5owx3y
+
 **Winners Announcement:** https://x.com/ohayo_dojo/status/1995548529927094746
 
 ## Winners

--- a/gj8/README.md
+++ b/gj8/README.md
@@ -12,6 +12,8 @@ Teams will come together for **3 days** to build games on the open-source, prova
 
 ## Getting Started
 
+[**Register on Luma**](https://luma.com/w1wxpfv3)
+
 [**Register your game idea here**](https://github.com/dojoengine/game-jams/issues/new?assignees=&labels=&projects=&template=register_project.yaml&title=%5BProject+Registration%5D:+Your+Project+Name)
 
 If you're looking for teammates or game ideas, head over to the **#game-jam** channel in the [Dojo Discord](https://discord.gg/tHezCAA4).


### PR DESCRIPTION
Added Luma registration links for both game jams.
- gj8: Registration link in Getting Started section
- gj7: Registration link in event metadata

🤖 Generated with Claude Code