### PR TITLE
docs: add registration_url to gj7 and gj8 frontmatter

### DIFF
--- a/gj7/README.md
+++ b/gj7/README.md
@@ -2,6 +2,7 @@
 start_date: "2025-10-31"
 end_date: "2025-11-03"
 prize_pool: "$15,000"
+registration_url: "https://luma.com/ug5owx3y"
 ---
 
 # Game Jam VII

--- a/gj8/README.md
+++ b/gj8/README.md
@@ -2,6 +2,7 @@
 start_date: "2026-03-06"
 end_date: "2026-03-08"
 prize_pool: "$15,000"
+registration_url: "https://luma.com/w1wxpfv3"
 ---
 
 # Dojo Game Jam VIII


### PR DESCRIPTION
Adds the Luma registration links to the YAML frontmatter per FRONTMATTER.md spec.
This enables the Daimyo client to render registration buttons on the landing page for both Game Jam VII and Game Jam VIII.

- gj7: https://luma.com/ug5owx3y
- gj8: https://luma.com/w1wxpfv3