### PR TITLE
fix: only enrich newly added submission files

### DIFF
--- a/.github/workflows/submission-enrich.yml
+++ b/.github/workflows/submission-enrich.yml
@@ -18,10 +18,10 @@ jobs:
         with:
           fetch-depth: 2
 
-      - name: Find new/modified submissions
+      - name: Find new submissions
         id: changed
         run: |
-          files=$(git diff --name-only HEAD~1 HEAD -- 'gj*/*.md' | grep -v README.md || true)
+          files=$(git diff --diff-filter=A --name-only HEAD~1 HEAD -- 'gj*/*.md' | grep -v README.md || true)
           if [ -z "$files" ]; then
             echo "skip=true" >> "$GITHUB_OUTPUT"
           else


### PR DESCRIPTION
The Enrich Submissions workflow was triggering unnecessarily when existing submission files were modified (e.g., during SDK field refactoring). This caused CI failures because the workflow runs on push events, which aren't supported by claude-code-action in tag mode.

Changed git diff filter to `--diff-filter=A` to only detect newly added files, preventing accidental runs when existing submissions are updated.