### PR TITLE
enrich: add bolding to prose fields across gj4-7 submissions

### DIFF
--- a/gj4/abyssx.md
+++ b/gj4/abyssx.md
@@ -4,8 +4,8 @@ repo_unavailable: true
 emoji: "🕳️"
 title: "AbyssX"
 summary_short: >
-  Roguelike dungeon crawler where adventurers descend into a mysterious bottomless cavern,
-  confronting creatures and harvesting treasures while acquiring skills and blessings.
+  **Roguelike dungeon crawler** where adventurers descend into a mysterious bottomless cavern,
+  confronting creatures and **harvesting treasures** while acquiring **skills and blessings**.
 summary_long: >
   AbyssX is a **roguelike dungeon crawler** set in a vast bottomless cavern called "X" where
   adventurers descend deeper into unknown depths. Players confront dangerous creatures, harvest
@@ -14,12 +14,12 @@ summary_long: >
   and irreversible curses as players forge ahead to uncover the abyss's true secrets. The
   repository is private/unavailable for **metric analysis**.
 work_done_short: >
-  Built a Unity-based roguelike dungeon crawler with Dojo integration during the jam.
-  Repository is unavailable for detailed analysis.
+  Built a **Unity-based roguelike dungeon crawler** with **Dojo integration** during the jam.
+  Repository is **unavailable** for detailed analysis.
 work_done_long: >
-  Developed a roguelike dungeon crawler using Unity and Dojo Engine. Implemented creature
-  encounters, treasure harvesting, and skill/blessing systems. Repository is private
-  or deleted, preventing detailed metric analysis. Gameplay demonstrated via YouTube video.
+  Developed a **roguelike dungeon crawler** using **Unity and Dojo Engine**. Implemented creature
+  encounters, treasure harvesting, and **skill/blessing systems**. Repository is private
+  or deleted, preventing detailed metric analysis. Gameplay demonstrated via **YouTube video**.
 repo_url: "https://github.com/mcjkn007/AbyssXDemo"
 demo_url: null
 video_url: "https://www.youtube.com/watch?v=j8g6KALxocc"

--- a/gj4/amneszia.md
+++ b/gj4/amneszia.md
@@ -3,8 +3,8 @@ id: "amneszia"
 emoji: "🧠"
 title: "Amneszia"
 summary_short: >
-  Multi-player Memory-like game using the Blobert NFT collection where players gain private
-  intel and prove tile matches using zero-knowledge proofs.
+  **Multi-player Memory-like game** using the Blobert NFT collection where players gain private
+  intel and prove tile matches using **zero-knowledge proofs**.
 summary_long: >
   Amneszia is a **multi-player Memory-like game** built around the Blobert NFT collection.
   Bloberts are revealed for only a few seconds, and players must gain private intel to match
@@ -13,12 +13,12 @@ summary_long: >
   live on Vercel**. All 14 commits were made during the jam, making it a complete
   **jam-built project**.
 work_done_short: >
-  Built a complete ZK-based memory matching game with 5 Dojo models, 2 systems, and
-  live Vercel deployment during the jam.
+  Built a complete **ZK-based memory matching game** with **5 Dojo models, 2 systems**, and
+  **live Vercel deployment** during the jam.
 work_done_long: >
-  Developed Dojo contracts with 5 models and 2 systems for tile state, player matching,
-  and ZK proof verification. Built a separate frontend deployed on Vercel. All 14 commits
-  made during the jam period. Game uses zero-knowledge proofs for hidden information mechanics.
+  Developed **Dojo contracts with 5 models and 2 systems** for tile state, player matching,
+  and **ZK proof verification**. Built a separate frontend **deployed on Vercel**. All 14 commits
+  made during the jam period. Game uses **zero-knowledge proofs** for hidden information mechanics.
 repo_url: "https://github.com/tekkac/amneszia-dojo"
 demo_url: "https://amneszia.vercel.app/"
 video_url: null

--- a/gj4/blob-arena.md
+++ b/gj4/blob-arena.md
@@ -3,8 +3,8 @@ id: "blob-arena"
 emoji: "🥊"
 title: "Blob Arena"
 summary_short: >
-  Pokemon-like battle game featuring Blobert NFTs in strategic rock-paper-scissors combat
-  modified by each character's unique attributes.
+  **Pokemon-like battle game** featuring Blobert NFTs in **strategic rock-paper-scissors combat**
+  modified by each character's **unique attributes**.
 summary_long: >
   Blob Arena is a **Pokemon-inspired battle game** where Blobert characters engage in strategic
   combat. Players navigate through encounters using their Bloberts' distinctive traits to
@@ -13,13 +13,13 @@ summary_long: >
   All 19 commits were made during the jam. Available as local setup with a Unity client for
   **visual battle rendering**.
 work_done_short: >
-  Built a complete Blobert battle game with 6 Dojo models, 3 systems, PvP and AI modes,
+  Built a complete **Blobert battle game** with **6 Dojo models, 3 systems**, **PvP and AI modes**,
   all during the jam window.
 work_done_long: >
-  Developed Dojo contracts with 6 models and 3 systems for character attributes, battle
-  state, and combat resolution. Implemented enhanced rock-paper-scissors mechanics modified
-  by Blobert traits. Supports PvP and AI opponents. All 19 commits during the jam. Local
-  setup with Unity client.
+  Developed **Dojo contracts with 6 models and 3 systems** for character attributes, battle
+  state, and combat resolution. Implemented **enhanced rock-paper-scissors mechanics** modified
+  by Blobert traits. Supports **PvP and AI opponents**. All 19 commits during the jam. Local
+  setup with **Unity client**.
 repo_url: "https://github.com/GrugLikesRocks/Blob-arena/"
 demo_url: null
 video_url: null

--- a/gj4/blobbar.md
+++ b/gj4/blobbar.md
@@ -3,8 +3,8 @@ id: "blobbar"
 emoji: "🍹"
 title: "Blobbar"
 summary_short: >
-  Blobert bartending game built with Three.js where players mix drinks for NFT characters,
-  featuring 4 Dojo models and 7 systems with frontend SDK integration.
+  **Blobert bartending game** built with **Three.js** where players mix drinks for NFT characters,
+  featuring **4 Dojo models and 7 systems** with **frontend SDK integration**.
 summary_long: >
   Blobbar is a **Blobert bartending game** built with Three.js and Dojo. Players serve drinks
   to Blobert NFT characters in a bar setting, though the frontend was admittedly **buggy at
@@ -12,12 +12,12 @@ summary_long: >
   integration** for real-time state updates. Built solo with 89% of 27 commits during the jam,
   the game requires **local setup** with Katana, Torii, and the development client.
 work_done_short: >
-  Built a Three.js bartending game with 4 Dojo models, 7 systems, and frontend SDK,
-  with 89% of commits during the jam.
+  Built a **Three.js bartending game** with **4 Dojo models, 7 systems**, and **frontend SDK**,
+  with **89% of commits** during the jam.
 work_done_long: >
-  Developed Dojo contracts with 4 models and 7 systems for drink mixing, Blobert
-  interactions, and bar state management. Integrated the Dojo frontend SDK for real-time
-  updates. Built with Three.js for the visual client. 24 of 27 commits (89%) during
+  Developed **Dojo contracts with 4 models and 7 systems** for drink mixing, Blobert
+  interactions, and bar state management. Integrated the **Dojo frontend SDK** for real-time
+  updates. Built with **Three.js** for the visual client. **24 of 27 commits (89%)** during
   the jam. Local setup only.
 repo_url: "https://github.com/ZackAmes/blobbar"
 demo_url: null

--- a/gj4/blobert-puzzle.md
+++ b/gj4/blobert-puzzle.md
@@ -3,8 +3,8 @@ id: "blobert-puzzle"
 emoji: "🧩"
 title: "Blobert Puzzle"
 summary_short: >
-  Collaborative onchain puzzle where Blobert NFT owners each hold a piece, working together
-  on Starknet mainnet to reveal a hidden masterpiece.
+  **Collaborative onchain puzzle** where Blobert NFT owners each hold a piece, working together
+  on **Starknet mainnet** to reveal a **hidden masterpiece**.
 summary_long: >
   Blobert Puzzle is a **collaborative onchain puzzle** deployed on Starknet mainnet where
   each Blobert NFT owner possesses a piece of a collective puzzle. Players work together to
@@ -13,12 +13,12 @@ summary_long: >
   The game is **live on mainnet** at blobertpuzzle.xyz, making it one of the few jam projects
   deployed to production.
 work_done_short: >
-  Built and deployed a collaborative NFT puzzle game on Starknet mainnet with 3 Dojo
-  models, 2 systems, and frontend SDK integration.
+  Built and **deployed on Starknet mainnet** a collaborative NFT puzzle game with **3 Dojo
+  models, 2 systems**, and **frontend SDK integration**.
 work_done_long: >
-  Developed Dojo contracts with 3 models and 2 systems for puzzle piece ownership,
-  placement validation, and collaborative assembly. Integrated the Dojo frontend SDK.
-  Deployed live on Starknet mainnet at blobertpuzzle.xyz. All 5 commits during the jam.
+  Developed **Dojo contracts with 3 models and 2 systems** for puzzle piece ownership,
+  placement validation, and collaborative assembly. Integrated the **Dojo frontend SDK**.
+  **Deployed live on Starknet mainnet** at blobertpuzzle.xyz. All **5 commits during the jam**.
 repo_url: "https://github.com/Await-0x/blobert-puzzle"
 demo_url: "https://blobertpuzzle.xyz/"
 video_url: null

--- a/gj4/blobert-showdown.md
+++ b/gj4/blobert-showdown.md
@@ -3,8 +3,8 @@ id: "blobert-showdown"
 emoji: "⚡"
 title: "Blobert Showdown"
 summary_short: >
-  Pokemon Showdown-inspired onchain game where players engage in tactical Blobert battles
-  using element types and strategic move selection.
+  **Pokemon Showdown-inspired onchain game** where players engage in **tactical Blobert battles**
+  using **element types** and strategic move selection.
 summary_long: >
   Blobert Showdown is a **Pokemon Showdown-inspired onchain game** where players engage in
   tactical battles using Bloberts with various elements and moves. Through strategic
@@ -13,12 +13,12 @@ summary_long: >
   battle system. All 47 commits were made during the jam. The game promotes **transparency
   and decentralized gaming** through onchain mechanics.
 work_done_short: >
-  Built a complete Pokemon-style battle game with 13 Dojo models, 3 systems, element
-  types, and strategic combat, all during the jam.
+  Built a complete **Pokemon-style battle game** with **13 Dojo models, 3 systems**, element
+  types, and strategic combat, **all during the jam**.
 work_done_long: >
-  Developed Dojo contracts with 13 models and 3 systems for Blobert stats, element types,
-  move sets, battle state, and ranking. Integrated the Dojo frontend SDK. Implemented
-  team building and ranked arena climbing mechanics. All 47 commits during the jam.
+  Developed **Dojo contracts with 13 models and 3 systems** for Blobert stats, element types,
+  move sets, battle state, and ranking. Integrated the **Dojo frontend SDK**. Implemented
+  **team building and ranked arena climbing** mechanics. All **47 commits during the jam**.
   Demo available via README.
 repo_url: "https://github.com/ML-Village/draft-blobert-showdown"
 demo_url: null

--- a/gj4/dodgeballer.md
+++ b/gj4/dodgeballer.md
@@ -3,8 +3,8 @@ id: "dodgeballer"
 emoji: "🏐"
 title: "Dodgeballer"
 summary_short: >
-  Blobert NFT-based dodgeball game where players mint unique Dodgeball NFTs from their
-  Blobert traits, earn Dodgecoin by hitting bullseyes with cannonballs.
+  **Blobert NFT-based dodgeball game** where players **mint unique Dodgeball NFTs** from their
+  Blobert traits, earn **Dodgecoin** by hitting bullseyes with cannonballs.
 summary_long: >
   DodgeBaller is a **Blobert NFT-powered dodgeball game** built with Phaser. Players mint
   unique Dodgeball NFTs derived from their Blobert's armor, weapon, and material traits,
@@ -13,13 +13,13 @@ summary_long: >
   Dojo markers, the project has 39 total commits with **95% made during the jam**. Deployed
   live on Vercel with **Starknet mainnet wallet** connection.
 work_done_short: >
-  Built a Phaser-based dodgeball game with NFT minting and Dodgecoin economy,
-  deployed live on Vercel with mainnet integration.
+  Built a **Phaser-based dodgeball game** with **NFT minting** and **Dodgecoin economy**,
+  **deployed live on Vercel** with mainnet integration.
 work_done_long: >
-  Developed a Phaser-based game with NFT minting mechanics that derive Dodgeball NFT
-  attributes from Blobert traits. Implemented a Dodgecoin token economy with earning
-  and spending mechanics. Uses Phaser rather than standard Dojo contract markers. 37 of
-  39 commits (95%) during the jam. Deployed live on Vercel.
+  Developed a **Phaser-based game** with **NFT minting mechanics** that derive Dodgeball NFT
+  attributes from Blobert traits. Implemented a **Dodgecoin token economy** with earning
+  and spending mechanics. Uses Phaser rather than standard Dojo contract markers. **37 of
+  39 commits (95%)** during the jam. **Deployed live on Vercel**.
 repo_url: "https://github.com/satyambnsal/dodgeballers"
 demo_url: "https://dodgeballers.vercel.app/"
 video_url: null

--- a/gj4/moving-mountains-with-yu.md
+++ b/gj4/moving-mountains-with-yu.md
@@ -3,8 +3,8 @@ id: "moving-mountains-with-yu"
 emoji: "🏔️"
 title: "Moving Mountains With Yu"
 summary_short: >
-  Cookie Clicker-inspired idle game on Katana L3 where all population increases are
-  onchain transactions, featuring totem upgrades and strategic progression.
+  **Cookie Clicker-inspired idle game** on **Katana L3** where all population increases are
+  **onchain transactions**, featuring totem upgrades and **strategic progression**.
 summary_long: >
   Moving Mountains With Yu is a **Cookie Clicker-inspired idle game** leveraging Katana L3's
   low gas costs for fully onchain interactions. Players produce Blobert population by clicking
@@ -13,13 +13,13 @@ summary_long: >
   totems with **strategic upgrade paths**. Built with 4 Dojo models and 2 systems with
   **frontend SDK integration**, 97% of 32 commits were made during the jam.
 work_done_short: >
-  Built an idle clicker game with 4 Dojo models, 2 systems, and frontend SDK,
-  with all interactions fully onchain via Katana L3.
+  Built an **idle clicker game** with **4 Dojo models, 2 systems**, and **frontend SDK**,
+  with all interactions **fully onchain via Katana L3**.
 work_done_long: >
-  Developed Dojo contracts with 4 models and 2 systems for population tracking, click
-  multipliers, and totem upgrade mechanics. Integrated the Dojo frontend SDK for real-time
-  state synchronization. Designed all interactions as onchain transactions using Katana
-  L3's low gas costs. 31 of 32 commits (97%) during the jam. Video demo only.
+  Developed **Dojo contracts with 4 models and 2 systems** for population tracking, click
+  multipliers, and totem upgrade mechanics. Integrated the **Dojo frontend SDK** for real-time
+  state synchronization. Designed all interactions as **onchain transactions using Katana
+  L3's low gas costs**. **31 of 32 commits (97%)** during the jam. Video demo only.
 repo_url: "https://github.com/FrostStarBook/moving-mountains-with-yu"
 demo_url: null
 video_url: "https://www.youtube.com/watch?v=wopJoorMcQA"

--- a/gj4/tale-weaver.md
+++ b/gj4/tale-weaver.md
@@ -3,8 +3,8 @@ id: "tale-weaver"
 emoji: "📖"
 title: "Tale Weaver"
 summary_short: >
-  AI-powered interactive storytelling game using DALL-E rendering and blockchain integration
-  via Dojo, with Blobert NFT contest mode.
+  **AI-powered interactive storytelling** game using **DALL-E rendering** and **blockchain integration
+  via Dojo**, with **Blobert NFT contest mode**.
 summary_long: >
   Tale Weaver is an **AI-powered interactive storytelling** game that crafts immersive narratives
   rendered through DALL-E image generation. Every player choice shapes the journey, creating
@@ -13,12 +13,12 @@ summary_long: >
   Built with 6 models, 3 systems, and 1 event with frontend SDK. The "v2-gamejam" designation
   and 39% jam commits indicate **significant pre-existing work** extended during the jam.
 work_done_short: >
-  Extended an existing AI storytelling platform with Blobert NFT integration and Dojo
-  contracts during the jam, with 39% of commits in the jam window.
+  Extended an existing **AI storytelling platform** with **Blobert NFT integration** and **Dojo
+  contracts** during the jam, with **39% of commits** in the jam window.
 work_done_long: >
-  Built on a pre-existing storytelling platform (v2), adding Dojo contracts with 6 models,
-  3 systems, and 1 event for onchain game state. Integrated Blobert NFTs for a contest mode.
-  Frontend uses the Dojo SDK. Only 14 of 36 commits (39%) during the jam, indicating
+  Built on a pre-existing storytelling platform (v2), adding **Dojo contracts with 6 models,
+  3 systems, and 1 event** for onchain game state. Integrated **Blobert NFTs** for a contest mode.
+  Frontend uses the **Dojo SDK**. Only **14 of 36 commits (39%)** during the jam, indicating
   significant prior work. Requires API keys for local setup.
 repo_url: "https://github.com/taleweaver-ai/taleweaver-v2-gamejam"
 demo_url: null

--- a/gj4/zklash.md
+++ b/gj4/zklash.md
@@ -3,8 +3,8 @@ id: "zklash"
 emoji: "🗡️"
 title: "zKlash"
 summary_short: >
-  Onchain autobattler where players buy creatures and strategically improve them to
-  survive progressively harder waves of enemies.
+  **Onchain autobattler** where players buy creatures and **strategically improve** them to
+  survive **progressively harder waves** of enemies.
 summary_long: >
   zKlash is a **fully onchain autobattler** built by the prolific z-korp team. Players
   purchase creatures and strategically improve them to survive increasingly difficult
@@ -13,13 +13,13 @@ summary_long: >
   the z-korp team's high output reflects their **experienced development pace**. Deployed
   live on Vercel with a **gameplay video** available.
 work_done_short: >
-  Built an autobattler with 9 Dojo models and frontend SDK, deployed live on Vercel,
+  Built an **autobattler** with **9 Dojo models** and **frontend SDK**, **deployed live on Vercel**,
   with 222 jam-period commits out of 418 total.
 work_done_long: >
-  Developed Dojo contracts with 9 models for creature management, battle state, wave
-  progression, and shop mechanics. Integrated the frontend SDK for real-time battle
-  visualization. 222 of 418 commits (53%) during the jam period. Deployed live on
-  Vercel with a YouTube gameplay demo.
+  Developed **Dojo contracts with 9 models** for creature management, battle state, wave
+  progression, and shop mechanics. Integrated the **frontend SDK** for real-time battle
+  visualization. **222 of 418 commits (53%)** during the jam period. **Deployed live on
+  Vercel** with a YouTube gameplay demo.
 repo_url: "https://github.com/z-korp/zklash"
 demo_url: "https://zklash-seven.vercel.app/"
 video_url: "https://www.youtube.com/watch?v=6wtSFphFvfw"

--- a/gj5/bu.md
+++ b/gj5/bu.md
@@ -3,8 +3,8 @@ id: "bu"
 emoji: "👻"
 title: "Bu at the Mu"
 summary_short: >
-  Tower defense game where players build towers to defend a tunnel from ghosts
-  emerging from a portal, built with Dojo and deployed on Vercel.
+  **Tower defense game** where players build towers to defend a tunnel from ghosts
+  emerging from a portal, built with **Dojo** and **deployed on Vercel**.
 summary_long: >
   Bu at the Mu is a **tower defense game** where players strategically place towers to stop
   ghosts coming out of a portal. Built on Dojo with 3 models and 1 system, the game features
@@ -12,12 +12,12 @@ summary_long: >
   the jam window, it was built almost entirely during the event. **Deployed live on Vercel**
   with a separate contracts repository for the Dojo backend.
 work_done_short: >
-  Built a complete tower defense game with 3 Dojo models, 1 system, and frontend SDK,
-  deployed live on Vercel during the jam.
+  Built a complete **tower defense game** with **3 Dojo models, 1 system**, and **frontend SDK**,
+  **deployed live on Vercel** during the jam.
 work_done_long: >
-  Developed Dojo contracts with 3 models and 1 system for tower placement, ghost spawning,
-  and defense mechanics. Integrated the Dojo frontend SDK for real-time state updates.
-  Deployed live on Vercel. 39 of 41 commits (95%) during the jam period. Separate
+  Developed Dojo contracts with **3 models and 1 system** for tower placement, ghost spawning,
+  and defense mechanics. Integrated the **Dojo frontend SDK** for real-time state updates.
+  **Deployed live on Vercel**. 39 of 41 commits (**95%**) during the jam period. Separate
   contracts repository at shramee/zashmu-contracts.
 repo_url: "https://github.com/ZackAmes/bu"
 demo_url: "https://bu-three.vercel.app/"

--- a/gj5/depths-of-dread.md
+++ b/gj5/depths-of-dread.md
@@ -3,8 +3,8 @@ id: "depths-of-dread"
 emoji: "🏚️"
 title: "Depths of Dread"
 summary_short: >
-  Top-down roguelike with pixel art where players memorize codes to navigate obscured
-  dungeon floors filled with traps, enemies, and treasures.
+  **Top-down roguelike** with pixel art where players **memorize codes** to navigate obscured
+  dungeon floors filled with **traps, enemies, and treasures**.
 summary_long: >
   Depths of Dread is a **top-down roguelike** with pixel art and dungeon environments. Players
   receive a code at the start of each level that they must **memorize to complete the floor**.
@@ -13,12 +13,12 @@ summary_long: >
   for real-time updates. 70% of 66 commits were made during the jam. Requires **local setup**
   to play.
 work_done_short: >
-  Built a roguelike dungeon game with 7 Dojo models, 1 system, 7 events, and
-  frontend SDK integration during the jam.
+  Built a **roguelike dungeon game** with **7 Dojo models, 1 system, 7 events**, and
+  **frontend SDK** integration during the jam.
 work_done_long: >
-  Developed Dojo contracts with 7 models, 1 system, and 7 events for level generation,
-  trap placement, enemy behavior, and score tracking. Integrated the Dojo frontend SDK.
-  Built pixel art visual client for the dungeon environment. 46 of 66 commits (70%)
+  Developed Dojo contracts with **7 models, 1 system, and 7 events** for level generation,
+  trap placement, enemy behavior, and score tracking. Integrated the **Dojo frontend SDK**.
+  Built **pixel art visual client** for the dungeon environment. 46 of 66 commits (**70%**)
   during the jam. Local setup only.
 repo_url: "https://github.com/joeperpetua/depths-of-dread-backend"
 demo_url: null

--- a/gj5/dtanks.md
+++ b/gj5/dtanks.md
@@ -3,8 +3,8 @@ id: "dtanks"
 emoji: "🎯"
 title: "DTanks"
 summary_short: >
-  Deceptive tank warfare game where players command 6 real tanks and 6 dummy decoys,
-  using terrain and misdirection to reach 1,500 points first.
+  **Deceptive tank warfare game** where players command 6 real tanks and **6 dummy decoys**,
+  using **terrain and misdirection** to reach 1,500 points first.
 summary_long: >
   DTanks is a **deceptive tank warfare game** where players command a mix of 6 real tanks and
   6 dummy decoys. Victory requires both **combat skill and clever misdirection** as players
@@ -12,12 +12,12 @@ summary_long: >
   SDK integration**, all 14 commits were made during the jam. **Deployed live on Vercel**
   with a playable demo and a **YouTube gameplay video** available.
 work_done_short: >
-  Built a complete tank warfare game with 7 Dojo models, 5 systems, and frontend SDK,
-  all during the jam with live Vercel deployment.
+  Built a complete **tank warfare game** with **7 Dojo models, 5 systems**, and **frontend SDK**,
+  all during the jam with **live Vercel deployment**.
 work_done_long: >
-  Developed Dojo contracts with 7 models and 5 systems for tank movement, combat resolution,
-  decoy management, and scoring. Integrated the Dojo frontend SDK for real-time state.
-  All 14 commits during the jam. Deployed live on Vercel at dtanks.vercel.app with
+  Developed Dojo contracts with **7 models and 5 systems** for tank movement, combat resolution,
+  decoy management, and scoring. Integrated the **Dojo frontend SDK** for real-time state.
+  All **14 commits during the jam**. **Deployed live on Vercel** at dtanks.vercel.app with
   YouTube gameplay demo.
 repo_url: "https://github.com/Kagwep/dtanks"
 demo_url: "https://dtanks.vercel.app/"

--- a/gj5/jokers-neon-x-loot-survivor-mod.md
+++ b/gj5/jokers-neon-x-loot-survivor-mod.md
@@ -3,8 +3,8 @@ id: "jokers-neon-x-loot-survivor-mod"
 emoji: "🃏"
 title: "Jokers of Neon x Loot Survivor Mod"
 summary_short: >
-  Community mod for Jokers of Neon integrating Loot Survivor mechanics, dead adventurers,
-  and collectible beasts into the card game, deployed on Starknet mainnet.
+  **Community mod** for Jokers of Neon integrating **Loot Survivor** mechanics, dead adventurers,
+  and collectible beasts into the card game, **deployed on Starknet mainnet**.
 summary_long: >
   Jokers of Neon x Loot Survivor Mod is a **community mod** for the Jokers of Neon card game,
   incorporating gameplay mechanics and elements from **Loot Survivor** including dead adventurers
@@ -13,13 +13,13 @@ summary_long: >
   **deployed on Starknet mainnet** at ls.jokersofneon.com. Built by the 5-person **Caravana
   Studio** team.
 work_done_short: >
-  Built a Loot Survivor mod for Jokers of Neon with 46 models, 10 systems, 39 events,
-  deployed to mainnet during the jam.
+  Built a **Loot Survivor mod** for Jokers of Neon with **46 models, 10 systems, 39 events**,
+  **deployed to mainnet** during the jam.
 work_done_long: >
-  Extended the Jokers of Neon contracts with 46 models, 10 systems, and 39 events for
-  Loot Survivor integration including adventurer and beast mechanics. Separate contracts
-  and client repositories. 57 of 65 commits (88%) during the jam. Deployed on Starknet
-  mainnet at ls.jokersofneon.com.
+  Extended the Jokers of Neon contracts with **46 models, 10 systems, and 39 events** for
+  **Loot Survivor integration** including adventurer and beast mechanics. Separate contracts
+  and client repositories. 57 of 65 commits (**88%**) during the jam. **Deployed on Starknet
+  mainnet** at ls.jokersofneon.com.
 repo_url: "https://github.com/caravana-studio/jokers-ls-mod-contracts"
 demo_url: "https://ls.jokersofneon.com/"
 video_url: null

--- a/gj5/rugged.md
+++ b/gj5/rugged.md
@@ -3,8 +3,8 @@ id: "rugged"
 emoji: "💰"
 title: "Rugged"
 summary_short: >
-  High-risk trading simulator where players avoid getting rugged to become Team Members,
-  then choose between holding for dividends or rugging others.
+  **High-risk trading simulator** where players avoid getting rugged to become **Team Members**,
+  then choose between **holding for dividends** or **rugging others**.
 summary_long: >
   Rugged is a **high-risk trading simulator** by Haus of Sosij. Players face a 30% chance
   of getting rugged in phase 1; survivors become **Team Members** who must decide how long
@@ -12,12 +12,12 @@ summary_long: >
   models, 1 system, and 2 events with **frontend SDK integration**. 80% of 15 commits were
   during the jam. Phase 1 deployed to **Sepolia testnet** with a **YouTube gameplay video**.
 work_done_short: >
-  Built a two-phase trading simulator with 3 Dojo models, 1 system, 2 events,
-  and frontend SDK, deployed to Sepolia during the jam.
+  Built a **two-phase trading simulator** with **3 Dojo models, 1 system, 2 events**,
+  and **frontend SDK**, deployed to **Sepolia** during the jam.
 work_done_long: >
-  Developed Dojo contracts with 3 models, 1 system, and 2 events for rug mechanics,
-  team membership, and dividend distribution. Integrated the Dojo frontend SDK.
-  Deployed phase 1 to Sepolia testnet. 12 of 15 commits (80%) during the jam.
+  Developed Dojo contracts with **3 models, 1 system, and 2 events** for rug mechanics,
+  team membership, and dividend distribution. Integrated the **Dojo frontend SDK**.
+  **Deployed phase 1 to Sepolia testnet**. 12 of 15 commits (**80%**) during the jam.
   YouTube gameplay video demonstrates the JS-based client.
 repo_url: "https://github.com/PoulavBhowmick03/rugged01"
 demo_url: null

--- a/gj5/skeleton-smash.md
+++ b/gj5/skeleton-smash.md
@@ -3,8 +3,8 @@ id: "skeleton-smash"
 emoji: "💀"
 title: "Skeleton Smash"
 summary_short: >
-  Halloween-themed platformer where players control a pumpkin navigating eerie landscapes,
-  available on Telegram and web with live deployment.
+  **Halloween-themed platformer** where players control a pumpkin navigating eerie landscapes,
+  available on **Telegram and web** with **live deployment**.
 summary_long: >
   Skeleton Smash is a **Halloween-themed platformer** where players control a fearless pumpkin
   navigating eerie landscapes filled with spine-chilling surprises. Built with 6 Dojo models
@@ -12,12 +12,12 @@ summary_long: >
   the jam. **Deployed live** on both Telegram (@SkeletonSmashBot) and the web at
   skeleton-smash.pages.dev, making it **accessible across platforms** without installation.
 work_done_short: >
-  Built a cross-platform Halloween platformer with 6 Dojo models, 2 systems, and
-  frontend SDK, deployed on Telegram and web during the jam.
+  Built a **cross-platform Halloween platformer** with **6 Dojo models, 2 systems**, and
+  **frontend SDK**, deployed on **Telegram and web** during the jam.
 work_done_long: >
-  Developed Dojo contracts with 6 models and 2 systems for player movement, enemy
-  encounters, and scoring. Integrated the Dojo frontend SDK. Deployed on both Telegram
-  and Cloudflare Pages for cross-platform access. 136 of 143 commits (95%) during
+  Developed Dojo contracts with **6 models and 2 systems** for player movement, enemy
+  encounters, and scoring. Integrated the **Dojo frontend SDK**. Deployed on both **Telegram
+  and Cloudflare Pages** for cross-platform access. 136 of 143 commits (**95%**) during
   the jam. Published under RuneLabsxyz.
 repo_url: "https://github.com/RuneLabsxyz/skeleton-smash/"
 demo_url: "https://skeleton-smash.pages.dev"

--- a/gj5/strategic-nexus.md
+++ b/gj5/strategic-nexus.md
@@ -4,8 +4,8 @@ repo_unavailable: true
 emoji: "🗺️"
 title: "Strategic Nexus"
 summary_short: >
-  Web3 adventure game where players collect items and evade enemies using Dojo's Move
-  and Spawn features, navigating obstacles with strategic item abilities.
+  **Web3 adventure game** where players collect items and **evade enemies** using **Dojo's Move
+  and Spawn features**, navigating obstacles with **strategic item abilities**.
 summary_long: >
   Strategic Nexus is a **Web3 adventure game** utilizing Dojo's Move and Spawn features.
   Players navigate a vibrant world, collecting items like the Fire Suit, Key, and Sword while
@@ -13,12 +13,12 @@ summary_long: >
   that open new challenges and pathways. The repository is private/unavailable for metric
   analysis. A **Loom demo video** demonstrates the gameplay.
 work_done_short: >
-  Built a Web3 adventure game using Dojo's Move and Spawn features. Repository is
-  unavailable for detailed analysis.
+  Built a **Web3 adventure game** using **Dojo's Move and Spawn features**. Repository is
+  **unavailable** for detailed analysis.
 work_done_long: >
-  Developed a Web3 adventure game with item collection and enemy evasion mechanics
-  using Dojo contracts. Separate contracts repository. Repository is private or deleted,
-  preventing detailed metric analysis. Gameplay demonstrated via Loom video.
+  Developed a **Web3 adventure game** with **item collection and enemy evasion** mechanics
+  using Dojo contracts. Separate contracts repository. Repository is **private or deleted**,
+  preventing detailed metric analysis. Gameplay demonstrated via **Loom video**.
 repo_url: "https://github.com/AkankshaAttavar/Strategic-Nexus"
 demo_url: null
 video_url: "https://www.loom.com/share/8af646b2d283451a9e79f4b70396f38d"

--- a/gj5/the-marquis-checkers.md
+++ b/gj5/the-marquis-checkers.md
@@ -3,8 +3,8 @@ id: "the-marquis-checkers"
 emoji: "♟️"
 title: "The Marquis: Checkers"
 summary_short: >
-  Fully onchain checkers game on Starknet using Dojo Engine, part of The Marquis gaming
-  platform, with all game logic implemented in smart contracts.
+  **Fully onchain checkers game** on Starknet using **Dojo Engine**, part of **The Marquis** gaming
+  platform, with all game logic implemented in **smart contracts**.
 summary_long: >
   The Marquis: Checkers is a **fully onchain checkers game** implemented using the Dojo Engine
   on Starknet Layer 2. All game logic including player moves, validations, and win conditions
@@ -12,13 +12,13 @@ summary_long: >
   1 system, and 4 events with **frontend SDK integration**. Part of **The Marquis** gaming
   platform, with 25% of 167 commits during the jam. A **Loom demo video** showcases gameplay.
 work_done_short: >
-  Added onchain checkers to The Marquis platform with 4 Dojo models, 1 system,
-  4 events, and frontend SDK during the jam.
+  Added **onchain checkers** to The Marquis platform with **4 Dojo models, 1 system,
+  4 events**, and **frontend SDK** during the jam.
 work_done_long: >
-  Developed Dojo contracts with 4 models, 1 system, and 4 events for checkers game
-  logic, move validation, and win conditions. Integrated the Dojo frontend SDK.
+  Developed Dojo contracts with **4 models, 1 system, and 4 events** for checkers game
+  logic, **move validation, and win conditions**. Integrated the **Dojo frontend SDK**.
   Part of The Marquis gaming platform. 42 of 167 commits (25%) during the jam.
-  Gameplay demonstrated via Loom video.
+  Gameplay demonstrated via **Loom video**.
 repo_url: "https://github.com/The-Marquis-Gaming/checkers-dojo"
 demo_url: null
 video_url: "https://www.loom.com/share/59af22d54b2542bd92db39fb4245876d"

--- a/gj5/waifu-awrpg.md
+++ b/gj5/waifu-awrpg.md
@@ -3,8 +3,8 @@ id: "waifu-awrpg"
 emoji: "🎮"
 title: "Waifu-AWRPG"
 summary_short: >
-  Free-to-use onchain protocol for creators to upload moddable waifu assets and invite
-  friends to play, built with Phaser and Dojo.
+  **Free-to-use onchain protocol** for creators to upload **moddable waifu assets** and invite
+  friends to play, built with **Phaser and Dojo**.
 summary_long: >
   Waifu-AWRPG is a **free-to-use onchain protocol** for creators to upload moddable waifu
   assets and invite friends to play. Built with **Phaser and Dojo**, players can spawn heroes,
@@ -13,12 +13,12 @@ summary_long: >
   **local deployment** with burner wallet support. Plans include IPFS/Arweave integration
   and **AI protocol** support for immersive UX.
 work_done_short: >
-  Built an onchain RPG protocol with 18 Dojo models, 12 systems, 2 events, and
-  frontend SDK using Phaser during the jam.
+  Built an **onchain RPG protocol** with **18 Dojo models, 12 systems, 2 events**, and
+  **frontend SDK** using **Phaser** during the jam.
 work_done_long: >
-  Developed Dojo contracts with 18 models, 12 systems, and 2 events for hero spawning,
-  combat mechanics, and asset management. Built visual client with Phaser. Integrated
-  the Dojo frontend SDK with burner wallet support. 26 of 34 commits (76%) during
+  Developed Dojo contracts with **18 models, 12 systems, and 2 events** for hero spawning,
+  combat mechanics, and asset management. Built visual client with **Phaser**. Integrated
+  the **Dojo frontend SDK** with **burner wallet support**. 26 of 34 commits (76%) during
   the jam. Local deployment only with Google Drive video demo.
 repo_url: "https://github.com/BriefCandle/dojo-gamejam"
 demo_url: null

--- a/gj5/zoker.md
+++ b/gj5/zoker.md
@@ -4,8 +4,8 @@ repo_unavailable: true
 emoji: "⚽"
 title: "ZoKer"
 summary_short: >
-  Fully onchain football manager game powered by Dojo, Controller, and Paymaster,
-  playable via Telegram and web with community-driven tournaments.
+  **Fully onchain football manager game** powered by **Dojo, Controller, and Paymaster**,
+  playable via **Telegram and web** with **community-driven tournaments**.
 summary_long: >
   ZoKer is a **fully onchain football manager game** powered by Dojo, Controller, and
   Paymaster. Players build dream teams and compete in **PvP matches and season tournaments**
@@ -14,12 +14,12 @@ summary_long: >
   repository is private/unavailable for metric analysis. **Deployed live** on Vercel with
   a Telegram bot for accessible gameplay.
 work_done_short: >
-  Built an onchain football manager game with Dojo, Controller, and Paymaster.
-  Repository is unavailable for detailed analysis.
+  Built an **onchain football manager game** with **Dojo, Controller, and Paymaster**.
+  Repository is **unavailable** for detailed analysis.
 work_done_long: >
-  Developed a football manager game using Dojo with Controller and Paymaster integration
-  for frictionless blockchain experience. Features PvP matches, tournaments, and internal
-  market. Telegram bot integration. Repository is private or deleted, preventing detailed
+  Developed a **football manager game** using Dojo with **Controller and Paymaster** integration
+  for frictionless blockchain experience. Features **PvP matches, tournaments, and internal
+  market**. **Telegram bot** integration. Repository is private or deleted, preventing detailed
   metric analysis. Live deployment on Vercel.
 repo_url: "https://github.com/Gianfranco99/ZoKer-Game-Jam"
 demo_url: "https://football-mini-game.vercel.app/"

--- a/gj6/ashwood.md
+++ b/gj6/ashwood.md
@@ -3,8 +3,8 @@ id: "ashwood"
 emoji: "⚔️"
 title: "Ashwood"
 summary_short: >
-  Fully onchain tactical strategy game where players command armies across a 54-position
-  battlefield divided into 6 tactical zones with seasonal warfare and supply chain logistics.
+  **Fully onchain tactical strategy game** where players command armies across a **54-position
+  battlefield** divided into 6 tactical zones with **seasonal warfare** and supply chain logistics.
 summary_long: >
   Ashwood is a **fully onchain tactical strategy game** built on Starknet using Dojo.
   Players command armies across a **54-position battlefield** divided into 6 tactical zones,
@@ -13,13 +13,13 @@ summary_long: >
   and 120-round battles where winners claim ownership of NFT units. A rich frontend with
   **Dojo SDK integration** delivers the complete strategic experience.
 work_done_short: >
-  Built a complete tactical strategy game with 8 models, 4 systems, 13 events,
-  seasonal warfare, supply logistics, and Dojo SDK during the jam.
+  Built a **complete tactical strategy game** with **8 models, 4 systems, 13 events**,
+  seasonal warfare, supply logistics, and **Dojo SDK** during the jam.
 work_done_long: >
-  Developed Dojo contracts with 8 models, 4 systems, and 13 events for army management,
-  tactical zone control, seasonal effects, and combat resolution. 6 unique unit classes
-  with distinct movement patterns. Integrated the Dojo frontend SDK. All 13 commits
-  during the jam. Deployed live on Vercel with YouTube tutorial.
+  Developed Dojo contracts with **8 models, 4 systems, and 13 events** for army management,
+  tactical zone control, seasonal effects, and combat resolution. **6 unique unit classes**
+  with distinct movement patterns. Integrated the **Dojo frontend SDK**. All 13 commits
+  during the jam. **Deployed live on Vercel** with YouTube tutorial.
 repo_url: "https://github.com/Kagwep/ashwood"
 demo_url: "https://ashwood.vercel.app/"
 video_url: "https://youtu.be/1PGdqDZSXrY"

--- a/gj6/caps.md
+++ b/gj6/caps.md
@@ -3,8 +3,8 @@ id: "caps"
 emoji: "♟️"
 title: "Caps"
 summary_short: >
-  Fast-paced chess-like board game where pieces have special abilities, featuring 4 teams,
-  elo-based matchmaking, and a Daydreams AI opponent.
+  **Fast-paced chess-like board game** where pieces have special abilities, featuring 4 teams,
+  **elo-based matchmaking**, and a **Daydreams AI opponent**.
 summary_long: >
   Caps is a **fast-paced chess-like board game** where pieces have special abilities. Players
   choose from 4 teams with varied playstyles, competing via **elo-based matchmaking** or
@@ -12,13 +12,13 @@ summary_long: >
   **frontend SDK integration**. Mobile-friendly design. 18% of 149 commits were during the
   jam window. **Deployed live on Vercel** with invite functionality for direct challenges.
 work_done_short: >
-  Built a chess-like board game with 15 Dojo models, 4 systems, elo matchmaking,
-  and AI opponent, deployed on Vercel during the jam.
+  Built a chess-like board game with **15 Dojo models, 4 systems**, **elo matchmaking**,
+  and **AI opponent**, deployed on Vercel during the jam.
 work_done_long: >
-  Developed Dojo contracts with 15 models, 4 systems, and 1 event for piece abilities,
-  team selection, elo ranking, and match state. Integrated Daydreams AI agent as opponent.
-  Dojo frontend SDK for real-time state. 27 of 149 commits (18%) during the jam.
-  Deployed live on Vercel with mobile-friendly design.
+  Developed Dojo contracts with **15 models, 4 systems, and 1 event** for piece abilities,
+  team selection, elo ranking, and match state. Integrated **Daydreams AI agent** as opponent.
+  **Dojo frontend SDK** for real-time state. 27 of 149 commits (18%) during the jam.
+  **Deployed live on Vercel** with mobile-friendly design.
 repo_url: "https://github.com/ZackAmes/caps-jam"
 demo_url: "https://caps-jam.vercel.app/"
 video_url: null

--- a/gj6/craftisland-exploration.md
+++ b/gj6/craftisland-exploration.md
@@ -4,8 +4,8 @@ repo_unavailable: true
 emoji: "🏝️"
 title: "Craft Island: Exploration"
 summary_short: >
-  Flying ship exploration feature for Craft Island where players access procedurally
-  generated islands to gather resources, built with Unreal Engine 5 and Dojo.
+  **Flying ship exploration** feature for Craft Island where players access **procedurally
+  generated islands** to gather resources, built with **Unreal Engine 5 and Dojo**.
 summary_long: >
   Craft Island: Exploration adds **island exploration** to the existing Craft Island prototype.
   Players use a flying ship to access **procedurally generated islands** and gather new
@@ -14,12 +14,12 @@ summary_long: >
   demo. AI tools used for 3D asset generation (Rodin AI) and contract development (Claude Code).
   The repository is private/unavailable for **metric analysis**.
 work_done_short: >
-  Added procedural island exploration to Craft Island with UE5 and Dojo.
-  Repository is unavailable for detailed analysis.
+  Added **procedural island exploration** to Craft Island with **UE5 and Dojo**.
+  Repository is **unavailable** for detailed analysis.
 work_done_long: >
-  Extended the Craft Island prototype with procedural island generation, resource gathering,
-  onboarding quests, and mobile controls. Used Unreal Engine 5 with Dojo contracts. AI-assisted
-  development with Claude Code and Rodin AI for 3D assets. TestFlight demo available. Repository
+  Extended the Craft Island prototype with **procedural island generation**, resource gathering,
+  onboarding quests, and mobile controls. Used **Unreal Engine 5** with Dojo contracts. **AI-assisted
+  development** with Claude Code and Rodin AI for 3D assets. **TestFlight demo** available. Repository
   is private or deleted, preventing detailed metric analysis.
 repo_url: "https://github.com/caillef/craft-island"
 demo_url: null

--- a/gj6/detective-game.md
+++ b/gj6/detective-game.md
@@ -3,8 +3,8 @@ id: "detective-game"
 emoji: "🔍"
 title: "Detective Game"
 summary_short: >
-  Blockchain-first murder mystery where players interrogate AI-powered suspects to solve
-  crimes, with accusations and stats recorded onchain via Dojo.
+  **Blockchain-first murder mystery** where players interrogate **AI-powered suspects** to solve
+  crimes, with accusations and stats **recorded onchain** via Dojo.
 summary_long: >
   Detective Game is a **blockchain-first murder mystery** where players interrogate AI-powered
   suspects to solve a crime. Each session allows a single accusation, with the outcome recorded
@@ -13,12 +13,12 @@ summary_long: >
   1 system, and 2 events. All 23 commits during the jam. **Deployed live on Vercel** with
   custom React + Tailwind frontend.
 work_done_short: >
-  Built a complete AI-powered murder mystery with 3 Dojo models, 1 system, 2 events,
-  and live Vercel deployment during the jam.
+  Built a complete **AI-powered murder mystery** with **3 Dojo models, 1 system, 2 events**,
+  and **live Vercel deployment** during the jam.
 work_done_long: >
-  Developed Dojo contracts with 3 models, 1 system, and 2 events for game state,
-  accusations, and player stats. Integrated GPT for AI suspect dialogue. Built custom
-  React + Tailwind frontend. All 23 commits during the jam. Deployed live on Vercel
+  Developed Dojo contracts with **3 models, 1 system, and 2 events** for game state,
+  accusations, and player stats. Integrated **GPT for AI suspect dialogue**. Built custom
+  **React + Tailwind frontend**. All 23 commits during the jam. **Deployed live on Vercel**
   at detective-game-iota.vercel.app.
 repo_url: "https://github.com/EthanPerello/detective-game"
 demo_url: "https://detective-game-iota.vercel.app"

--- a/gj6/echoes-of-the-void.md
+++ b/gj6/echoes-of-the-void.md
@@ -3,8 +3,8 @@ id: "echoes-of-the-void"
 emoji: "🔊"
 title: "Echoes of the Void"
 summary_short: >
-  Minimalist puzzle-platformer where players navigate pitch-black procedurally generated
-  chambers using only sound pulses, with all moves as onchain transactions.
+  **Minimalist puzzle-platformer** where players navigate pitch-black **procedurally generated
+  chambers** using only sound pulses, with all moves as **onchain transactions**.
 summary_long: >
   Echoes of the Void is a **minimalist puzzle-platformer** where players navigate pitch-black,
   procedurally generated chambers using only sound. Every move and sound pulse is a **provable
@@ -13,13 +13,13 @@ summary_long: >
   with **frontend SDK integration**. 97% of 34 commits during the jam. Requires **local setup**
   with Katana and Torii.
 work_done_short: >
-  Built a sound-based puzzle-platformer with 3 Dojo models, 1 system, 5 events,
-  and frontend SDK during the jam.
+  Built a **sound-based puzzle-platformer** with **3 Dojo models, 1 system, 5 events**,
+  and **frontend SDK** during the jam.
 work_done_long: >
-  Developed Dojo contracts with 3 models, 1 system, and 5 events for chamber generation,
-  movement validation, pulse mechanics, and map discovery. Procedural generation from
-  onchain seeds. Integrated the Dojo frontend SDK. 33 of 34 commits (97%) during
-  the jam. Local setup with Katana and Torii.
+  Developed Dojo contracts with **3 models, 1 system, and 5 events** for chamber generation,
+  movement validation, pulse mechanics, and map discovery. **Procedural generation from
+  onchain seeds**. Integrated the **Dojo frontend SDK**. 33 of 34 commits (97%) during
+  the jam. **Local setup** with Katana and Torii.
 repo_url: "https://github.com/bitfalt/echoes-of-the-void"
 demo_url: null
 video_url: null

--- a/gj6/elven-escape.md
+++ b/gj6/elven-escape.md
@@ -3,8 +3,8 @@ id: "elven-escape"
 emoji: "🧝"
 title: "Elven Escape"
 summary_short: >
-  Adventure game where players traverse a mystical forest seeking escape, encountering
-  shrines, gatekeepers, and deadly traps with an ego and greed system.
+  **Adventure game** where players traverse a mystical forest seeking escape, encountering
+  shrines, gatekeepers, and deadly traps with an **ego and greed system**.
 summary_long: >
   Elven Escape is an **adventure game** where players embark on a journey through a mystical
   forest seeking escape. Players encounter **ancient shrines** offering powerful blessings and
@@ -13,12 +13,12 @@ summary_long: >
   attracting danger. Built with 8 models, 1 system, and 7 events with **Dojo SDK integration**.
   All 20 commits during the jam. **Deployed live on Vercel**.
 work_done_short: >
-  Built a complete adventure game with 8 Dojo models, 1 system, 7 events, ego/greed
-  mechanics, and live Vercel deployment during the jam.
+  Built a **complete adventure game** with **8 Dojo models, 1 system, 7 events**, ego/greed
+  mechanics, and **live Vercel deployment** during the jam.
 work_done_long: >
-  Developed Dojo contracts with 8 models, 1 system, and 7 events for player progression,
-  shrine interactions, gatekeeper combat, trap mechanics, and ego/greed tracking. Integrated
-  the Dojo frontend SDK. All 20 commits during the jam. Deployed live on Vercel
+  Developed Dojo contracts with **8 models, 1 system, and 7 events** for player progression,
+  shrine interactions, gatekeeper combat, trap mechanics, and **ego/greed tracking**. Integrated
+  the **Dojo frontend SDK**. All 20 commits during the jam. **Deployed live on Vercel**
   at elvenescape.vercel.app.
 repo_url: "https://github.com/Kishore-MK/elvenescape"
 demo_url: "https://elvenescape.vercel.app/"

--- a/gj6/golem-runner.md
+++ b/gj6/golem-runner.md
@@ -3,8 +3,8 @@ id: "golem-runner"
 emoji: "🏃"
 title: "Golem Runner"
 summary_short: >
-  Mobile-first endless runner with elemental golems featuring an AI-powered daily missions
-  system with onchain persistence, deployed live on Sepolia.
+  **Mobile-first endless runner** with elemental golems featuring an **AI-powered daily missions
+  system** with **onchain persistence**, deployed live on Sepolia.
 summary_long: >
   Golem Runner is a **mobile-first endless runner** where players control elemental golems
   racing through mystical realms. For this jam, the team built an **AI-powered daily missions
@@ -13,13 +13,13 @@ summary_long: >
   reward system. Built with 5 models and 1 system with **frontend SDK integration**. 11% of
   100 commits during the jam. **Deployed live on Sepolia** at golemrunner.live.
 work_done_short: >
-  Added AI-powered daily missions to Golem Runner with 5 Dojo models, 1 system,
-  and Eliza AI agent, deployed on Sepolia during the jam.
+  Added **AI-powered daily missions** to Golem Runner with **5 Dojo models, 1 system**,
+  and **Eliza AI agent**, deployed on Sepolia during the jam.
 work_done_long: >
-  Extended Golem Runner with AI-generated daily missions using Eliza AI agent. Developed
-  Dojo contracts with 5 models and 1 system for mission generation, progress tracking,
-  and reward claims. Integrated the Dojo frontend SDK. 11 of 100 commits (11%) during
-  the jam. Deployed live on Sepolia at golemrunner.live with YouTube demo.
+  Extended Golem Runner with **AI-generated daily missions** using Eliza AI agent. Developed
+  Dojo contracts with **5 models and 1 system** for mission generation, progress tracking,
+  and reward claims. Integrated the **Dojo frontend SDK**. 11 of 100 commits (11%) during
+  the jam. **Deployed live on Sepolia** at golemrunner.live with YouTube demo.
 repo_url: "https://github.com/AkatsukiLabs/GolemRunner"
 demo_url: "https://golemrunner.live/"
 video_url: "https://youtube.com/shorts/QJrE3gRWE0c"

--- a/gj6/moon-bag-vibes.md
+++ b/gj6/moon-bag-vibes.md
@@ -3,8 +3,8 @@ id: "moon-bag-vibes"
 emoji: "🌙"
 title: "Moon Bag Vibes"
 summary_short: >
-  Cosmic-themed push-your-luck rogue-like bag-building game where players draw orbs
-  to score points while avoiding bombs, built with PixiJS and Dojo.
+  **Cosmic-themed push-your-luck rogue-like** bag-building game where players draw orbs
+  to score points while avoiding bombs, built with **PixiJS and Dojo**.
 summary_long: >
   Moon Bag Vibes is a **cosmic-themed push-your-luck rogue-like** bag-building game where
   players draw orbs from a bag to score points while avoiding bombs. Every tap of the moon
@@ -12,12 +12,12 @@ summary_long: >
   and survival. Built with 8 Dojo models and 1 system using **PixiJS for the client**. 89%
   of 72 commits during the jam. Requires **local setup** with Katana and Torii.
 work_done_short: >
-  Built a complete push-your-luck bag-building game with 8 Dojo models, 1 system,
-  and PixiJS client during the jam.
+  Built a complete **push-your-luck bag-building game** with **8 Dojo models, 1 system**,
+  and **PixiJS client** during the jam.
 work_done_long: >
-  Developed Dojo contracts with 8 models and 1 system for bag contents, orb drawing,
-  bomb mechanics, scoring, and round management. Built visual client with PixiJS.
-  64 of 72 commits (89%) during the jam. Local setup with Katana and Torii.
+  Developed Dojo contracts with **8 models and 1 system** for bag contents, orb drawing,
+  bomb mechanics, scoring, and round management. Built visual client with **PixiJS**.
+  **64 of 72 commits (89%)** during the jam. Local setup with Katana and Torii.
   No frontend SDK integration.
 repo_url: "https://github.com/elton-cs/moonbag-intro"
 demo_url: null

--- a/gj6/overgoal.md
+++ b/gj6/overgoal.md
@@ -3,8 +3,8 @@ id: "overgoal"
 emoji: "⚽"
 title: "Overgoal"
 summary_short: >
-  Mobile-first football career game where matches play out in arcade sequences while
-  off-field choices reshape stats and storyline, all stored onchain.
+  **Mobile-first football career game** where matches play out in **arcade sequences** while
+  off-field choices reshape stats and storyline, all **stored onchain**.
 summary_long: >
   Overgoal drops players into the life of a **rising football legend**. Matches play out in
   snappy, arcade-style sequences while off-field choices (endorsements, nightlife, training)
@@ -13,13 +13,13 @@ summary_long: >
   56% of 126 commits during the jam. **Mobile-first design** with local setup required.
   Match logic currently runs **client-side** with backend service in progress.
 work_done_short: >
-  Built a mobile-first football career game with 8 Dojo models, 1 system, 1 event,
-  and arcade match sequences during the jam.
+  Built a **mobile-first football career game** with **8 Dojo models, 1 system, 1 event**,
+  and **arcade match sequences** during the jam.
 work_done_long: >
-  Developed Dojo contracts with 8 models, 1 system, and 1 event for player stats,
-  career progression, match state, and off-field events. Integrated the Dojo frontend SDK.
-  Mobile-first React client with arcade-style match rendering. 70 of 126 commits (56%)
-  during the jam. Local setup with team seeding scripts.
+  Developed Dojo contracts with **8 models, 1 system, and 1 event** for player stats,
+  career progression, match state, and off-field events. Integrated the **Dojo frontend SDK**.
+  **Mobile-first React client** with arcade-style match rendering. 70 of 126 commits (56%)
+  during the jam. Local setup with **team seeding scripts**.
 repo_url: "https://github.com/mgrunwaldt/overgoal-game-repo"
 demo_url: null
 video_url: null

--- a/gj6/panda-panda.md
+++ b/gj6/panda-panda.md
@@ -3,8 +3,8 @@ id: "panda-panda"
 emoji: "🐼"
 title: "Panda Panda"
 summary_short: >
-  Browser-based tile-matching puzzle game inspired by Sheep a Sheep where players
-  strategically match tiles to clear levels, deployed on Slot and Render.
+  **Browser-based tile-matching puzzle** game inspired by Sheep a Sheep where players
+  strategically match tiles to clear levels, **deployed on Slot and Render**.
 summary_long: >
   Panda Panda is a **browser-based puzzle game** inspired by Sheep a Sheep, designed for
   desktop. Players must **match tiles strategically** to clear levels while managing limited
@@ -13,13 +13,13 @@ summary_long: >
   the jam. **Deployed on Slot** (Cartridge infrastructure) and **live on Render** with
   YouTube demo videos.
 work_done_short: >
-  Built a complete tile-matching puzzle with 3 Dojo models, 1 system, 4 events,
-  deployed on Slot and Render during the jam.
+  Built a complete **tile-matching puzzle** with **3 Dojo models, 1 system, 4 events**,
+  **deployed on Slot and Render** during the jam.
 work_done_long: >
-  Developed Dojo contracts with 3 models, 1 system, and 4 events for tile state,
-  matching logic, slot management, and scoring. Integrated the Dojo frontend SDK.
-  Deployed on Cartridge Slot infrastructure and Render. All 7 commits during the jam.
-  YouTube demo videos available.
+  Developed Dojo contracts with **3 models, 1 system, and 4 events** for tile state,
+  matching logic, slot management, and scoring. Integrated the **Dojo frontend SDK**.
+  Deployed on **Cartridge Slot infrastructure** and Render. All 7 commits during the jam.
+  **YouTube demo videos** available.
 repo_url: "https://github.com/dpinones/panda-panda"
 demo_url: "https://panda-panda.onrender.com"
 video_url: "https://www.youtube.com/shorts/F1BVz7NrzOQ"

--- a/gj6/playerzero.md
+++ b/gj6/playerzero.md
@@ -3,8 +3,8 @@ id: "playerzero"
 emoji: "💎"
 title: "Player Zero"
 summary_short: >
-  20-round onchain brawl where players scramble to stockpile Gold, Water, and Oil
-  through buying, sabotage, and market manipulation on Dojo and Starknet.
+  **20-round onchain brawl** where players scramble to stockpile Gold, Water, and Oil
+  through buying, **sabotage, and market manipulation** on **Dojo and Starknet**.
 summary_long: >
   Player Zero is a **20-round onchain brawl** on Dojo and Starknet where players scramble to
   stockpile Gold, Water, and Oil before anyone else. Every sneaky buy, cheeky sabotage, and
@@ -13,12 +13,12 @@ summary_long: >
   63% of 8 commits during the jam. **Deployed live on Vercel** with retro vibes and a
   Google Drive demo video.
 work_done_short: >
-  Built a complete commodity trading brawl with 5 Dojo models, 1 system, 6 events,
-  and live Vercel deployment during the jam.
+  Built a complete **commodity trading brawl** with **5 Dojo models, 1 system, 6 events**,
+  and **live Vercel deployment** during the jam.
 work_done_long: >
-  Developed Dojo contracts with 5 models, 1 system, and 6 events for resource trading,
-  sabotage mechanics, price dynamics, and round management. Integrated the Dojo frontend
-  SDK. 5 of 8 commits (63%) during the jam. Deployed live on Vercel with Google Drive
+  Developed Dojo contracts with **5 models, 1 system, and 6 events** for resource trading,
+  **sabotage mechanics**, price dynamics, and round management. Integrated the **Dojo frontend
+  SDK**. 5 of 8 commits (63%) during the jam. **Deployed live on Vercel** with Google Drive
   demo video.
 repo_url: "https://github.com/0xmukeshr/Player_zero"
 demo_url: "https://player-zero-final-1pot.vercel.app/"

--- a/gj6/ponzi-land.md
+++ b/gj6/ponzi-land.md
@@ -3,8 +3,8 @@ id: "ponzi-land"
 emoji: "🏗️"
 title: "Ponzi Land Mod"
 summary_short: >
-  Game mod for Ponzi Land adding a mini-map widget, sound effects for land interactions,
-  and fixing the buy land transaction functionality.
+  **Game mod** for Ponzi Land adding a **mini-map widget**, **sound effects** for land interactions,
+  and fixing the **buy land transaction** functionality.
 summary_long: >
   Ponzi Land Mod adds features to the existing **Ponzi Land** game including a **mini-map
   widget** showing a grid overview with color-coded owned and empty lands, **sound effects**
@@ -13,12 +13,12 @@ summary_long: >
   events with **frontend SDK integration**. All 3 commits during the jam. Submitted as a
   **Game Mod** track entry.
 work_done_short: >
-  Added mini-map widget, sound effects, and buy land fix to Ponzi Land with
+  Added **mini-map widget**, **sound effects**, and **buy land fix** to Ponzi Land with
   3 models, 3 systems, and 9 events during the jam.
 work_done_long: >
-  Extended Ponzi Land with a Svelte mini-map component showing color-coded land grid,
-  audio feedback for land interactions, and a critical buy land transaction fix.
-  Dojo contracts with 3 models, 3 systems, and 9 events. Integrated the Dojo frontend SDK.
+  Extended Ponzi Land with a **Svelte mini-map component** showing color-coded land grid,
+  audio feedback for land interactions, and a **critical buy land transaction fix**.
+  Dojo contracts with **3 models, 3 systems, and 9 events**. Integrated the **Dojo frontend SDK**.
   All 3 commits during the jam. Submitted as Game Mod track.
 repo_url: "https://github.com/ussyalfaks/PonziLand_Mod"
 demo_url: null

--- a/gj6/ruta-del-gallo-pinto.md
+++ b/gj6/ruta-del-gallo-pinto.md
@@ -3,8 +3,8 @@ id: "ruta-del-gallo-pinto"
 emoji: "🍳"
 title: "Ruta del Gallo Pinto"
 summary_short: >
-  2D digital board game set in Costa Rica where dog chefs navigate a grid to collect
-  ingredients and craft traditional recipes like Gallo Pinto and Casado.
+  **2D digital board game** set in Costa Rica where dog chefs navigate a grid to collect
+  ingredients and craft **traditional recipes** like Gallo Pinto and Casado.
 summary_long: >
   Ruta del Gallo Pinto is a **2D digital board game** set in the heart of Costa Rica. Players
   take on the role of charming dog chefs, navigating a **grid-based world** to collect essential
@@ -13,12 +13,12 @@ summary_long: >
   models and 1 system with **frontend SDK integration** using a React frontend. All 3 commits
   during the jam. Under **active development** with local setup required.
 work_done_short: >
-  Built a Costa Rican recipe board game with 6 Dojo models, 1 system, and
-  React frontend during the jam.
+  Built a **Costa Rican recipe board game** with **6 Dojo models, 1 system**, and
+  **React frontend** during the jam.
 work_done_long: >
-  Developed Dojo contracts with 6 models and 1 system for grid movement, ingredient
-  collection, recipe crafting, and player state. Built React frontend with Dojo SDK
-  integration. All 3 commits during the jam. Under active development with local
+  Developed Dojo contracts with **6 models and 1 system** for grid movement, ingredient
+  collection, **recipe crafting**, and player state. Built **React frontend with Dojo SDK
+  integration**. All 3 commits during the jam. Under **active development** with local
   setup only.
 repo_url: "https://github.com/kimcascante/Ruta-del-Gallo-Pinto"
 demo_url: null

--- a/gj6/song-of-camelot.md
+++ b/gj6/song-of-camelot.md
@@ -3,8 +3,8 @@ id: "song-of-camelot"
 emoji: "🏰"
 title: "Song of Camelot"
 summary_short: >
-  Onchain strategy game where players compete to dominate a map by strategically placing
-  elemental influences, with Cartridge wallet integration for onboarding.
+  **Onchain strategy game** where players compete to dominate a map by strategically placing
+  **elemental influences**, with **Cartridge wallet integration** for onboarding.
 summary_long: >
   Song of Camelot is an **onchain strategy game** where players compete to dominate a map by
   strategically placing elemental influences. Features a separate **Cartridge wallet login
@@ -12,13 +12,13 @@ summary_long: >
   **frontend SDK integration**. All 8 commits during the jam. Requires **local setup** with
   instructions in the repository README.
 work_done_short: >
-  Built a complete elemental strategy game with 6 Dojo models, 4 systems, and
-  Cartridge wallet integration during the jam.
+  Built a complete **elemental strategy game** with **6 Dojo models, 4 systems**, and
+  **Cartridge wallet integration** during the jam.
 work_done_long: >
-  Developed Dojo contracts with 6 models and 4 systems for map state, elemental
-  placement, influence mechanics, and competition logic. Integrated Cartridge wallet
-  login wrapper for user onboarding. Dojo frontend SDK integration. All 8 commits
-  during the jam. Local setup only.
+  Developed Dojo contracts with **6 models and 4 systems** for map state, elemental
+  placement, influence mechanics, and competition logic. Integrated **Cartridge wallet
+  login wrapper** for user onboarding. **Dojo frontend SDK** integration. All 8 commits
+  during the jam. **Local setup** only.
 repo_url: "https://github.com/gogibear/song-of-camelot"
 demo_url: null
 video_url: null

--- a/gj6/you-are-who-you-kill.md
+++ b/gj6/you-are-who-you-kill.md
@@ -3,8 +3,8 @@ id: "you-are-who-you-kill"
 emoji: "🧟"
 title: "You Are Who You Kill"
 summary_short: >
-  Frankenstein-style web3 game where players build their body from defeated enemies,
-  gaining stat bonuses from collected parts in turn-based PvE combat.
+  **Frankenstein-style web3 game** where players build their body from defeated enemies,
+  gaining **stat bonuses** from collected parts in **turn-based PvE combat**.
 summary_long: >
   You Are Who You Kill is a **Frankenstein-style web3 game** where players build their body
   from the enemies they defeat. Each part gives **stat bonuses** — HP, Damage, or Mobility —
@@ -13,12 +13,12 @@ summary_long: >
   SDK integration**. All 9 commits during the jam. Requires **local setup**. Long-term vision
   includes PvP and **modular NFT body parts**.
 work_done_short: >
-  Built a complete body-harvesting combat game with 17 Dojo models, 2 systems, 9 events,
-  and two demo levels during the jam.
+  Built a complete **body-harvesting combat game** with **17 Dojo models, 2 systems, 9 events**,
+  and **two demo levels** during the jam.
 work_done_long: >
-  Developed Dojo contracts with 17 models, 2 systems, and 9 events for body part
-  collection, stat bonuses, turn-based combat, obstacle interaction, and inventory
-  management. Integrated the Dojo frontend SDK. Two playable demo levels. All 9
+  Developed Dojo contracts with **17 models, 2 systems, and 9 events** for body part
+  collection, stat bonuses, **turn-based combat**, obstacle interaction, and inventory
+  management. Integrated the **Dojo frontend SDK**. **Two playable demo levels**. All 9
   commits during the jam. Local setup only.
 repo_url: "https://github.com/last-dot/you-are-who-you-kill"
 demo_url: null

--- a/gj7/butu.md
+++ b/gj7/butu.md
@@ -3,22 +3,22 @@ id: "butu"
 emoji: "👻"
 title: "Butu"
 summary_short: >
-  Plants-vs-zombies-inspired tower defense where ghosts assault player-built machine
-  defenses on a grid. Place turrets and traps to fend off waves of spectral invaders
-  in this fully on-chain strategy game.
+  **Plants-vs-zombies-inspired tower defense** where ghosts assault player-built machine
+  defenses on a grid. Place turrets and traps to fend off **waves of spectral invaders**
+  in this **fully on-chain strategy game**.
 summary_long: >
-  Butu reimagines tower defense with a ghost-vs-machine theme built on Starknet using
+  Butu reimagines tower defense with a **ghost-vs-machine theme** built on Starknet using
   Dojo. Players position mechanical defenses on a grid to stop advancing waves of
   ghosts. The Dojo backend uses 2 models and 1 system for game state management.
-  The frontend integrates the Dojo SDK for real-time state synchronization. Deployed
-  live on Vercel with automatic game state updates and a manual refresh fallback.
+  The frontend integrates the Dojo SDK for **real-time state synchronization**. **Deployed
+  live on Vercel** with automatic game state updates and a manual refresh fallback.
 work_done_short: >
-  Built a complete tower defense game from scratch during the jam with grid-based
-  placement, ghost waves, and machine defenses.
+  Built a **complete tower defense game from scratch** during the jam with **grid-based
+  placement**, ghost waves, and machine defenses.
 work_done_long: >
-  Developed Dojo contracts with 2 models and 1 system for on-chain game state
+  Developed Dojo contracts with 2 models and 1 system for **on-chain game state**
   including grid layout, defense placement, and wave progression. Built a frontend
-  with Dojo SDK integration for real-time updates. Deployed live on Vercel with
+  with **Dojo SDK integration** for real-time updates. **Deployed live on Vercel** with
   automatic state refresh.
 repo_url: "https://github.com/ZackAmes/butu"
 demo_url: "https://butu.vercel.app/"

--- a/gj7/chance-master.md
+++ b/gj7/chance-master.md
@@ -3,25 +3,25 @@ id: "chance-master"
 emoji: "🎲"
 title: "Chance Master"
 summary_short: >
-  Chess variant where dice rolls determine which piece type you can move each turn.
+  **Chess variant** where **dice rolls** determine which piece type you can move each turn.
   Three dice are rolled before every move, injecting suspense into classical chess
-  strategy and forcing creative improvisation under constraints.
+  strategy and forcing **creative improvisation** under constraints.
 summary_long: >
-  Chance Master combines classical chess with dice-driven piece selection, where players
+  Chance Master combines classical chess with **dice-driven piece selection**, where players
   roll three dice each turn to determine which piece types they can move. The game uses
-  ZK proofs for anti-cheat: Circom circuits produce Groth16 proofs of move legality,
+  **ZK proofs** for anti-cheat: Circom circuits produce Groth16 proofs of move legality,
   verified on-chain via Garaga on Starknet. Dojo ECS models store game state including
-  board, clock, and claims. Real-time multiplayer is powered by Torii WebSocket
-  subscriptions, and a permissive account policy flow enables sign-less gameplay.
+  board, clock, and claims. Real-time multiplayer is powered by **Torii WebSocket
+  subscriptions**, and a permissive account policy flow enables sign-less gameplay.
 work_done_short: >
-  Built a complete ZK-verified chess variant with dice mechanics, Circom proof generation,
-  on-chain Garaga verification, and real-time multiplayer via Torii.
+  Built a **complete ZK-verified chess variant** with dice mechanics, **Circom proof generation**,
+  on-chain Garaga verification, and **real-time multiplayer** via Torii.
 work_done_long: >
   Developed a full chess game with dice-based piece selection. Implemented Circom circuits
-  and snarkjs for Groth16 proof generation of move legality, with Cairo-based on-chain
-  verification using Garaga. Built Dojo contracts with 1 model, 1 system, and 1 event for
+  and snarkjs for **Groth16 proof generation** of move legality, with **Cairo-based on-chain
+  verification** using Garaga. Built Dojo contracts with 1 model, 1 system, and 1 event for
   game state management. Created a multiplayer frontend with WebSocket sync via Torii and
-  sign-less UX through permissive account policies.
+  **sign-less UX** through permissive account policies.
 repo_url: "https://github.com/armaanansari121/Chance-Master"
 demo_url: null
 video_url: "https://youtu.be/li_P68mlM-Y"

--- a/gj7/charon.md
+++ b/gj7/charon.md
@@ -3,23 +3,23 @@ id: "charon"
 emoji: "🚀"
 title: "Charon"
 summary_short: >
-  Space combat rescue game where creators design grid-based missions with enemy ships
-  and defenses, and rescuers pay entry fees to navigate through and claim rewards.
+  **Space combat rescue game** where creators design **grid-based missions** with enemy ships
+  and defenses, and rescuers pay entry fees to navigate through and **claim rewards**.
 summary_long: >
-  Charon is a space combat game built on Starknet with Dojo where players take on two
+  Charon is a **space combat rescue game** built on Starknet with Dojo where players take on two
   roles: mission creators and rescuers. Creators place target ships on a grid surrounded
   by enemy defenses, setting entry fees and rewards. Rescuers choose their ship, pay to
   enter, and navigate through defenses to claim the bounty. The Dojo backend uses 7 models
   and 8 systems to manage mission state, combat mechanics, ship configurations, and
-  leaderboards. Frontend SDK integration provides real-time state sync via Torii.
+  leaderboards. **Frontend SDK integration** provides real-time state sync via Torii.
 work_done_short: >
-  Built a complete space combat rescue game with mission creation, ship selection,
+  Built a **complete space combat rescue game** with **mission creation**, ship selection,
   grid-based navigation, combat, and leaderboards.
 work_done_long: >
-  Developed a full space combat game with an extensive Dojo backend comprising 7 models
+  Developed a full space combat game with an **extensive Dojo backend** comprising 7 models
   and 8 systems covering mission creation, ship configuration, combat resolution, reward
-  distribution, and leaderboard tracking. Built a frontend with Dojo SDK integration for
-  wallet connection and real-time state synchronization.
+  distribution, and leaderboard tracking. Built a frontend with **Dojo SDK integration** for
+  wallet connection and **real-time state synchronization**.
 repo_url: "https://github.com/Kagwep/charon"
 demo_url: "https://charon-mu.vercel.app/"
 video_url: "https://youtu.be/9oHpZzgP1kw"

--- a/gj7/destiny.md
+++ b/gj7/destiny.md
@@ -3,23 +3,23 @@ id: "destiny"
 emoji: "⚔️"
 title: "Destiny"
 summary_short: >
-  Turn-based RPG battle game where players command heroes against monsters across 3
-  difficulty levels. Features 9 skill types including offensive, support, and debuff
-  abilities with on-chain progression.
+  **Turn-based RPG battle game** where players command heroes against monsters across 3
+  difficulty levels. Features **9 skill types** including offensive, support, and debuff
+  abilities with **on-chain progression**.
 summary_long: >
-  Destiny is a fully on-chain turn-based RPG built on Starknet using Dojo. Players select
+  Destiny is a **fully on-chain turn-based RPG** built on Starknet using Dojo. Players select
   heroes and assign skills each turn to battle waves of monsters. The combat system features
   9 skill types spanning offensive attacks, healing, buffs, and debuffs, with critical hits,
   evasion, and defense calculations. Dojo manages game state through 2 models and 1 system
-  with 1 event. The frontend features pixel-art animated characters, sound effects, and
-  background music. Deployed live on Vercel with Cartridge Controller integration.
+  with 1 event. The frontend features **pixel-art animated characters**, sound effects, and
+  background music. **Deployed live on Vercel** with Cartridge Controller integration.
 work_done_short: >
-  Built a complete turn-based RPG with heroes, 9 skill types, 3 difficulty levels,
-  pixel-art animations, and live deployment.
+  Built a **complete turn-based RPG** with heroes, 9 skill types, 3 difficulty levels,
+  **pixel-art animations**, and **live deployment**.
 work_done_long: >
-  Developed a full turn-based RPG with Dojo contracts defining 2 models, 1 system, and 1
-  event for on-chain game state. Built a React frontend with pixel-art character animations,
-  sound effects, and background music. Implemented combat mechanics including critical hits,
+  Developed a full turn-based RPG with **Dojo contracts** defining 2 models, 1 system, and 1
+  event for on-chain game state. Built a React frontend with **pixel-art character animations**,
+  sound effects, and background music. Implemented **combat mechanics** including critical hits,
   evasion, and defense calculations across 3 progressive difficulty levels.
 repo_url: "https://github.com/SimplementeCao/dojo-game-jam-destiny"
 demo_url: "https://dojo-destiny.vercel.app/"

--- a/gj7/duels-x.md
+++ b/gj7/duels-x.md
@@ -3,23 +3,23 @@ id: "duels-x"
 emoji: "🃏"
 title: "Duels X"
 summary_short: >
-  Card battle game where players build decks of magical spells and engage in strategic
-  turn-based combat. Features damage, healing, buff, debuff, and special effect cards
-  with mechanics like Freeze, Shield, and Resurrection.
+  **Card battle game** where players build decks of magical spells and engage in **strategic
+  turn-based combat**. Features damage, healing, buff, debuff, and special effect cards
+  with mechanics like **Freeze, Shield, and Resurrection**.
 summary_long: >
-  Duels X is a card battle game built on Starknet using Dojo. Players build decks from
+  Duels X is a **card battle game** built on Starknet using Dojo. Players build decks from
   damage spells, healing, buffs, debuffs, and special effects. Combat revolves around
-  managing HP, ATK, and DEF stats while chaining card effects. Special mechanics include
+  managing HP, ATK, and DEF stats while **chaining card effects**. Special mechanics include
   Freeze, Shield, Double Damage, Resurrection, and persistent Aura effects. The Dojo
   backend uses 1 model and 2 systems with 1 event for on-chain state verification.
-  Deployed live on Vercel with Cartridge Controller integration.
+  **Deployed live on Vercel** with Cartridge Controller integration.
 work_done_short: >
-  Built a complete card battle game with deck building, multiple card types, special
-  effects, progressive difficulty, and live deployment.
+  Built a **complete card battle game** with **deck building**, multiple card types, special
+  effects, progressive difficulty, and **live deployment**.
 work_done_long: >
-  Developed a full card battle game with Dojo contracts defining 1 model, 2 systems, and
-  1 event for on-chain game state and combat logic. Implemented a rich card system with 5
-  card categories and special effects. Built a frontend with Cartridge Controller integration
+  Developed a full card battle game with **Dojo contracts** defining 1 model, 2 systems, and
+  1 event for on-chain game state and combat logic. Implemented a **rich card system** with 5
+  card categories and special effects. Built a frontend with **Cartridge Controller integration**
   and multiple difficulty levels.
 repo_url: "https://github.com/nlyrthiia/duels-x"
 demo_url: "https://duels-x-client.vercel.app/"

--- a/gj7/feral-forge.md
+++ b/gj7/feral-forge.md
@@ -3,24 +3,24 @@ id: "feral-forge"
 emoji: "🧌"
 title: "Feral Forge"
 summary_short: >
-  A fully on-chain 2048-style beast-merging puzzle game set in the Loot Survivor universe.
+  A **fully on-chain 2048-style beast-merging puzzle game** set in the Loot Survivor universe.
   Players slide beasts on a 4x4 grid to merge them into higher tiers and rare Shiny
-  variants, competing for high scores minted as soul-bound ERC-721 tokens.
+  variants, competing for high scores minted as **soul-bound ERC-721 tokens**.
 summary_long: >
-  Feral Forge reimagines the classic 2048 mechanic through the Loot Survivor bestiary.
+  Feral Forge reimagines the classic 2048 mechanic through the **Loot Survivor bestiary**.
   Players slide a 4x4 grid to merge same-tier beasts into stronger creatures, with matching
-  names producing coveted Shiny Beasts. Each game is minted as a soul-bound ERC-721 token
+  names producing coveted **Shiny Beasts**. Each game is minted as a soul-bound ERC-721 token
   with its own leaderboard that transfers to whoever beats the high score. The game uses
-  read-only contract methods for client-side gameplay and a single batch-submit transaction
+  read-only contract methods for **client-side gameplay** and a single batch-submit transaction
   at game end, enabling a mobile-friendly experience without per-move delays.
 work_done_short: >
-  Built a complete on-chain beast-merging puzzle game with ERC-721 leaderboard tokens,
-  batch move submission, and a mobile-optimized React client.
+  Built a **complete on-chain beast-merging puzzle game** with **ERC-721 leaderboard tokens**,
+  batch move submission, and a **mobile-optimized React client**.
 work_done_long: >
-  Developed Dojo smart contracts implementing 2048-style grid logic, beast tier merging,
-  Shiny variant detection, and ERC-721 token minting with per-game leaderboards. Designed
-  a batch move replay system and built a mobile-first React frontend integrated with
-  Cartridge Controller, requiring no indexer for state reads.
+  Developed **Dojo smart contracts** implementing 2048-style grid logic, beast tier merging,
+  Shiny variant detection, and **ERC-721 token minting** with per-game leaderboards. Designed
+  a **batch move replay system** and built a mobile-first React frontend integrated with
+  **Cartridge Controller**, requiring no indexer for state reads.
 repo_url: "https://github.com/rsodre/feral-forge"
 demo_url: "https://feral.beta.underware.gg/"
 video_url: null

--- a/gj7/ghost-grid.md
+++ b/gj7/ghost-grid.md
@@ -3,23 +3,23 @@ id: "ghost-grid"
 emoji: "👻"
 title: "Ghost Grid"
 summary_short: >
-  Phasmophobia-inspired on-chain ghost-hunting game on Starknet. Players investigate
-  haunted locations, gather evidence to identify ghost types, and compete on a global
-  leaderboard with all runs and scores recorded on-chain.
+  **Phasmophobia-inspired** on-chain **ghost-hunting game** on Starknet. Players investigate
+  haunted locations, gather evidence to identify ghost types, and compete on a **global
+  leaderboard** with all runs and scores recorded on-chain.
 summary_long: >
-  Ghost Grid brings paranormal investigation to the blockchain. Players explore haunted
+  Ghost Grid brings **paranormal investigation** to the blockchain. Players explore haunted
   environments, collect evidence clues, and deduce ghost types. Built on Dojo with 2 models,
   2 systems, and 2 events, the game writes all run data and scores on-chain to Starknet
-  Sepolia. A Torii indexer powers player profiles and a global leaderboard. The React + Vite
-  frontend uses Cartridge session keys so players interact without signing every action.
+  Sepolia. A **Torii indexer** powers player profiles and a global leaderboard. The React + Vite
+  frontend uses **Cartridge session keys** so players interact without signing every action.
 work_done_short: >
-  Built a complete ghost-hunting game with on-chain evidence tracking, player profiles,
-  leaderboard indexing via Torii, and Cartridge session keys.
+  Built a **complete ghost-hunting game** with **on-chain evidence tracking**, player profiles,
+  leaderboard indexing via Torii, and **Cartridge session keys**.
 work_done_long: >
-  Developed Dojo contracts with 2 models and 2 systems handling ghost run state, evidence
+  Developed **Dojo contracts** with 2 models and 2 systems handling ghost run state, evidence
   collection, and score recording, plus 2 events for game lifecycle tracking. Built a
-  React + Vite frontend integrating Cartridge session keys. Connected a Torii indexer for
-  real-time player profiles and leaderboard data. Deployed to Starknet Sepolia with a live
+  React + Vite frontend integrating **Cartridge session keys**. Connected a **Torii indexer** for
+  real-time player profiles and leaderboard data. **Deployed to Starknet Sepolia** with a live
   Vercel-hosted client.
 repo_url: "https://github.com/KaranSinghBisht/ghostgrid"
 demo_url: "https://ghostgrid.vercel.app/"

--- a/gj7/grim-block.md
+++ b/gj7/grim-block.md
@@ -3,25 +3,25 @@ id: "grim-block"
 emoji: "🧩"
 title: "Grim Block"
 summary_short: >
-  A fully on-chain Block Blast-style puzzle game. Players drag and drop tetris-like
-  pieces onto an 8x8 grid to clear lines, build combos, and compete on a global
-  leaderboard with all state verified on-chain.
+  A **fully on-chain Block Blast-style puzzle game**. Players drag and drop tetris-like
+  pieces onto an 8x8 grid to clear lines, build combos, and compete on a **global
+  leaderboard** with all state verified on-chain.
 summary_long: >
-  Grim Block is a fully on-chain puzzle game modeled after Block Blast, built with Dojo.
+  Grim Block is a **fully on-chain puzzle game** modeled after Block Blast, built with Dojo.
   Players place 19 unique piece types with 4 orientations each onto an 8x8 grid, clearing
-  rows and columns to earn points amplified by combo and streak multipliers. The grid is
-  stored as a single u64 using bit-packing, and up to 3 pieces are packed into one u32.
+  rows and columns to earn points amplified by **combo and streak multipliers**. The grid is
+  stored as a single u64 using **bit-packing**, and up to 3 pieces are packed into one u32.
   The React 19 frontend features drag-and-drop controls, optimistic UI updates, and a
-  Cartridge Controller wallet integration. A Torii indexer powers the global leaderboard.
+  Cartridge Controller wallet integration. A **Torii indexer** powers the global leaderboard.
 work_done_short: >
-  Built a complete on-chain Block Blast puzzle with 19 piece types, combo scoring,
-  bit-packed grid storage, and a polished React drag-and-drop frontend.
+  Built a **complete on-chain Block Blast puzzle** with 19 piece types, combo scoring,
+  **bit-packed grid storage**, and a **polished React drag-and-drop frontend**.
 work_done_long: >
-  Developed Dojo smart contracts implementing grid logic with u64 bit-packing, 19 piece
-  types with rotation support packed into u32, combo and streak scoring multipliers, and
+  Developed **Dojo smart contracts** implementing grid logic with u64 bit-packing, 19 piece
+  types with rotation support packed into u32, **combo and streak scoring multipliers**, and
   on-chain RNG piece generation. Built a React 19 + Vite frontend with drag-and-drop
-  placement, optimistic UI, and a paginated leaderboard. Integrated Cartridge Controller
-  and Torii for real-time indexing.
+  placement, optimistic UI, and a paginated leaderboard. Integrated **Cartridge Controller
+  and Torii** for real-time indexing.
 repo_url: "https://github.com/bal7hazar/grimblock"
 demo_url: "https://grimblock-client.vercel.app/"
 video_url: null

--- a/gj7/harvest-heist.md
+++ b/gj7/harvest-heist.md
@@ -3,23 +3,23 @@ id: "harvest-heist"
 emoji: "💰"
 title: "Harvest Heist"
 summary_short: >
-  A roguelike heist adventure where players infiltrate procedurally generated banks to
+  A **roguelike heist adventure** where players infiltrate **procedurally generated banks** to
   steal loot, dodge traps, and escape before the timer runs out. Loot is only permanent
-  if you return to the safe zone in time.
+  if you **return to the safe zone** in time.
 summary_long: >
-  Harvest Heist is a roguelike heist game built on Starknet using Dojo. Players explore
+  Harvest Heist is a **roguelike heist game** built on Starknet using Dojo. Players explore
   randomized bank rooms filled with traps, loot, and enemies, accumulating unbanked loot
   that must be secured by reaching the safe zone before time expires. The game features
-  progressive levels from training vaults to countryside stealth missions, plus upgrades
+  **progressive levels** from training vaults to countryside stealth missions, plus upgrades
   like speed boots, bigger bags, and timer extenders. Built with 1 Dojo model and 2 systems
-  for on-chain game state. Frontend SDK integration provides the browser interface.
+  for on-chain game state. **Frontend SDK integration** provides the browser interface.
 work_done_short: >
-  Built a complete roguelike heist game from scratch with procedural generation, timer
-  mechanics, upgrades, and a live deployment.
+  Built a **complete roguelike heist game from scratch** with **procedural generation**, timer
+  mechanics, upgrades, and a **live deployment**.
 work_done_long: >
-  Developed Dojo contracts with 1 model and 2 systems for on-chain game state including
-  bank layouts, loot tracking, and timer mechanics. Built a frontend with Dojo SDK
-  integration for real-time state synchronization. Implemented procedural level generation,
+  Developed **Dojo contracts** with 1 model and 2 systems for on-chain game state including
+  bank layouts, loot tracking, and timer mechanics. Built a frontend with **Dojo SDK
+  integration** for real-time state synchronization. Implemented **procedural level generation**,
   a loot banking system, and player upgrades across multiple heist levels.
 repo_url: "https://github.com/Ashar20/game3"
 demo_url: "https://harvestheist.vercel.app"

--- a/gj7/kanoodle-fusion.md
+++ b/gj7/kanoodle-fusion.md
@@ -3,25 +3,25 @@ id: "kanoodle-fusion"
 emoji: "🎨"
 title: "Kanoodle Fusion"
 summary_short: >
-  Blockchain-based color-mixing puzzle game where players place translucent polyomino
-  pieces on a 4x4 grid. Colors stack and blend additively to match target patterns
-  across 50 progressively challenging levels.
+  Blockchain-based **color-mixing puzzle game** where players place translucent polyomino
+  pieces on a 4x4 grid. Colors **stack and blend additively** to match target patterns
+  across **50 progressively challenging levels**.
 summary_long: >
-  Kanoodle Fusion is a spatial puzzle game built on Starknet using Dojo. Players place 13
+  Kanoodle Fusion is a **spatial puzzle game** built on Starknet using Dojo. Players place 13
   different polyomino pieces onto a 4x4 grid where primary colors (red, yellow, blue)
-  combine to create secondary colors (orange, green, purple). The game features 50 levels
-  of increasing difficulty, piece rotation and flipping, drag-and-drop controls, undo and
-  clear functionality, multi-language support, colorblind mode, and a Commodore 64 retro
-  aesthetic with CRT effects. All game state and logic stored on-chain.
+  combine to create secondary colors (orange, green, purple). The game features **50 levels
+  of increasing difficulty**, piece rotation and flipping, drag-and-drop controls, undo and
+  clear functionality, **multi-language support**, colorblind mode, and a **Commodore 64 retro
+  aesthetic** with CRT effects. All game state and logic stored on-chain.
 work_done_short: >
-  Built a complete color-mixing puzzle game with 50 levels, 13 piece types, additive
-  color blending, and a retro Commodore 64 aesthetic.
+  Built a **complete color-mixing puzzle game** with **50 levels**, 13 piece types, additive
+  color blending, and a **retro Commodore 64 aesthetic**.
 work_done_long: >
-  Developed a full puzzle game with Dojo contracts defining 1 model and 1 system for
-  on-chain game state. Implemented additive RGB color blending, 13 polyomino pieces with
-  rotation and flip transforms, 50 hand-designed levels, drag-and-drop controls, colorblind
-  accessibility mode, and multi-language support. Built a React frontend with Commodore 64
-  styling and CRT effects. Deployed live on Vercel.
+  Developed a full puzzle game with **Dojo contracts** defining 1 model and 1 system for
+  on-chain game state. Implemented **additive RGB color blending**, 13 polyomino pieces with
+  rotation and flip transforms, 50 hand-designed levels, drag-and-drop controls, **colorblind
+  accessibility mode**, and multi-language support. Built a React frontend with Commodore 64
+  styling and CRT effects. **Deployed live on Vercel**.
 repo_url: "https://github.com/dpinones/kanoodle-fusion"
 demo_url: "https://kanoodle-fusion.vercel.app/"
 video_url: "https://www.youtube.com/watch?v=eW0aSUBjs6c"

--- a/gj7/mastermind.md
+++ b/gj7/mastermind.md
@@ -3,24 +3,24 @@ id: "mastermind"
 emoji: "🧠"
 title: "ZK Word Mastermind"
 summary_short: >
-  Two-player code-breaking game combining classic Mastermind with zero-knowledge proofs.
-  Players guess each other's secret 4-character codes while ZK proofs verify feedback
-  honesty without revealing secrets.
+  **Two-player code-breaking game** combining classic Mastermind with **zero-knowledge proofs**.
+  Players guess each other's secret 4-character codes while ZK proofs **verify feedback
+  honesty** without revealing secrets.
 summary_long: >
-  ZK Word Mastermind brings the classic code-breaking game on-chain with cryptographic
-  guarantees. Two players each commit a Poseidon hash of their secret 4-letter code, then
+  ZK Word Mastermind brings the classic code-breaking game on-chain with **cryptographic
+  guarantees**. Two players each commit a Poseidon hash of their secret 4-letter code, then
   take turns guessing across up to 10 rounds. Feedback (hits and blows) is verified using
-  zero-knowledge proofs generated with Noir and verified via Garaga, ensuring honest
-  responses without premature revelation. Built on Dojo's ECS framework with Cartridge
-  Controller integration, real-time multiplayer matchmaking, and player statistics tracking.
+  **zero-knowledge proofs** generated with Noir and verified via Garaga, ensuring honest
+  responses without premature revelation. Built on Dojo's ECS framework with **Cartridge
+  Controller integration**, real-time multiplayer matchmaking, and player statistics tracking.
 work_done_short: >
-  Built a complete two-player ZK Mastermind game from scratch, including Dojo contracts,
-  ZK circuit design with Noir/Garaga, and a React frontend.
+  Built a **complete two-player ZK Mastermind game from scratch**, including Dojo contracts,
+  **ZK circuit design** with Noir/Garaga, and a React frontend.
 work_done_long: >
-  Developed the full game implementing Dojo models and systems for on-chain game state,
-  Poseidon hash commitments for secret codes, and ZK proof generation and verification
+  Developed the full game implementing **Dojo models and systems** for on-chain game state,
+  Poseidon hash commitments for secret codes, and **ZK proof generation and verification**
   using Noir circuits with Garaga. Built a React frontend with real-time game updates,
-  multiplayer matchmaking, and Cartridge Controller wallet integration.
+  multiplayer matchmaking, and **Cartridge Controller** wallet integration.
 repo_url: "https://github.com/truthixify/mastermind-dojo"
 demo_url: null
 video_url: null

--- a/gj7/onchain-excavator.md
+++ b/gj7/onchain-excavator.md
@@ -3,23 +3,23 @@ id: "onchain-excavator"
 emoji: "⛏️"
 title: "Onchain Excavator"
 summary_short: >
-  Treasure-mining strategy game where players compete to excavate digital mines, uncover
-  hidden treasures, and earn on-chain rewards. Every action from digging to claiming
-  finds is recorded on the blockchain.
+  **Treasure-mining strategy game** where players compete to excavate digital mines, uncover
+  hidden treasures, and earn **on-chain rewards**. Every action from digging to claiming
+  finds is **recorded on the blockchain**.
 summary_long: >
-  Onchain Excavator is a treasure-mining strategy game on Starknet where players compete
+  Onchain Excavator is a **treasure-mining strategy game** on Starknet where players compete
   to excavate digital mines and uncover hidden treasures. Built with Dojo, the game records
-  every action on-chain providing a provably fair mining experience. The project features
-  frontend SDK integration for real-time gameplay and a deployed live demo. While the
+  every action on-chain providing a **provably fair mining experience**. The project features
+  **frontend SDK integration** for real-time gameplay and a **deployed live demo**. While the
   repository predates the jam, significant feature work was contributed during the jam
   period adding new excavation mechanics and reward systems.
 work_done_short: >
-  Contributed significant feature additions during the jam, including new excavation
-  mechanics and on-chain reward systems on an existing repository.
+  Contributed **significant feature additions** during the jam, including **new excavation
+  mechanics** and **on-chain reward systems** on an existing repository.
 work_done_long: >
-  During the jam, approximately 52% of commits were made adding new game features. Work
-  included implementing Dojo models and systems for excavation gameplay, integrating the
-  frontend SDK for real-time state updates, and deploying a live demo. The project builds
+  During the jam, **approximately 52% of commits** were made adding new game features. Work
+  included implementing **Dojo models and systems** for excavation gameplay, integrating the
+  frontend SDK for real-time state updates, and **deploying a live demo**. The project builds
   on prior infrastructure with substantial jam-period contributions.
 repo_url: "https://github.com/felabs1/onchain_excavator"
 demo_url: "https://onchain-excavator.vercel.app"

--- a/gj7/scard.md
+++ b/gj7/scard.md
@@ -3,25 +3,25 @@ id: "scard"
 emoji: "🧟"
 title: "Scar'd"
 summary_short: >
-  Fully on-chain roguelike dungeon crawler. Navigate a haunted 5x5 grid, battle vampires
+  **Fully on-chain roguelike dungeon crawler**. Navigate a haunted 5x5 grid, battle vampires
   and werewolves, collect ability-enhancing gifts, and reach the exit. Each game exists as
-  a transferable ERC-721 token carrying all state.
+  a **transferable ERC-721 token** carrying all state.
 summary_long: >
-  Scar'd is a roguelike dungeon crawler built on Starknet with Dojo where players navigate
+  Scar'd is a **roguelike dungeon crawler** built on Starknet with Dojo where players navigate
   a 5x5 grid encountering weighted random events: free roam (40%), gifts (35%), and beast
-  encounters (25%). The game implements the Embeddable Game Standard, representing each game
-  as a transferable ERC-721 token that carries full state, enabling in-progress game trading.
-  Encounters are deterministically generated using Poseidon hashes. A dynamic SVG renderer
+  encounters (25%). The game implements the **Embeddable Game Standard**, representing each game
+  as a transferable ERC-721 token that carries full state, enabling **in-progress game trading**.
+  Encounters are deterministically generated using Poseidon hashes. A **dynamic SVG renderer**
   generates real-time visual representations of game state as token metadata. Built with 5
   Dojo models and 2 systems.
 work_done_short: >
-  Built a complete roguelike dungeon crawler from scratch, implementing the Embeddable Game
-  Standard with ERC-721 game tokens and Dojo-powered on-chain state.
+  Built a **complete roguelike dungeon crawler from scratch**, implementing the **Embeddable Game
+  Standard** with ERC-721 game tokens and Dojo-powered on-chain state.
 work_done_long: >
-  Developed 5 Dojo models and 2 systems managing game state, encounters, and combat.
-  Implemented ERC-721 tokens carrying transferable game state, a dynamic SVG renderer for
+  Developed **5 Dojo models and 2 systems** managing game state, encounters, and combat.
+  Implemented **ERC-721 tokens** carrying transferable game state, a **dynamic SVG renderer** for
   on-chain metadata, Poseidon hash-based deterministic encounter generation, weighted
-  probability distributions, and Cartridge Controller integration. Deployed live on Vercel.
+  probability distributions, and Cartridge Controller integration. **Deployed live on Vercel**.
 repo_url: "https://github.com/FemiOje/scard"
 demo_url: "https://scard-roan.vercel.app/"
 video_url: null

--- a/gj7/simula.md
+++ b/gj7/simula.md
@@ -3,23 +3,23 @@ id: "simula"
 emoji: "🏙️"
 title: "Simula"
 summary_short: >
-  An 8-bit city builder where players claim plots, construct buildings like gold mines and
-  energy plants, and manage resources that generate passively in real-time based on
+  An **8-bit city builder** where players claim plots, construct buildings like gold mines and
+  energy plants, and manage resources that **generate passively in real-time** based on
   elapsed time.
 summary_long: >
-  Simula is an 8-bit city builder on Starknet where players claim terrain plots and
+  Simula is an **8-bit city builder** on Starknet where players claim terrain plots and
   construct resource-generating buildings. Resources accrue passively based on elapsed time,
-  with offline progress calculated on return. The game uses a two-layer architecture: instant
+  with **offline progress** calculated on return. The game uses a **two-layer architecture**: instant
   client-side feedback with localStorage persistence, paired with blockchain validation for
   security. Built with Dojo using 6 models and 2 systems. While the repository predates
   the jam, targeted feature work was contributed during the jam period.
 work_done_short: >
-  Contributed targeted feature additions to an existing city builder codebase, enhancing
-  resource management and on-chain state synchronization.
+  Contributed **targeted feature additions** to an existing city builder codebase, enhancing
+  **resource management** and **on-chain state synchronization**.
 work_done_long: >
-  During the jam, approximately 8% of total commits were made, adding targeted features.
-  Work included refinements to Dojo models and systems for resource generation and
-  improvements to the client-blockchain architecture for state synchronization.
+  During the jam, **approximately 8% of total commits** were made, adding targeted features.
+  Work included refinements to **Dojo models and systems** for resource generation and
+  improvements to the **client-blockchain architecture** for state synchronization.
 repo_url: "https://github.com/marlonedwards/simula"
 demo_url: "https://worldrep.xyz/play/simula"
 video_url: null

--- a/gj7/stark-chess.md
+++ b/gj7/stark-chess.md
@@ -3,22 +3,22 @@ id: "stark-chess"
 emoji: "♟️"
 title: "StarkChess"
 summary_short: >
-  Fully on-chain chess on Starknet powered by Dojo Engine with Cartridge integration.
-  Features PvP and PvC modes with spectator prediction staking, where every move is
-  recorded immutably on-chain.
+  **Fully on-chain chess** on Starknet powered by Dojo Engine with Cartridge integration.
+  Features PvP and PvC modes with **spectator prediction staking**, where every move is
+  **recorded immutably** on-chain.
 summary_long: >
-  StarkChess brings chess fully on-chain on Starknet using the Dojo Engine and Cartridge
-  Controller. Players compete in PvP or PvC modes with all moves recorded immutably.
-  Spectator Prediction Staking lets viewers stake tokens on match outcomes, blending chess
-  with DeFi incentives. Note: the repository is no longer publicly accessible, but a video
-  demonstration shows the chess interface, move execution, and on-chain integration.
+  StarkChess brings chess fully on-chain on Starknet using the **Dojo Engine and Cartridge
+  Controller**. Players compete in PvP or PvC modes with all moves recorded immutably.
+  **Spectator Prediction Staking** lets viewers stake tokens on match outcomes, blending chess
+  with DeFi incentives. Note: the repository is no longer publicly accessible, but a **video
+  demonstration** shows the chess interface, move execution, and on-chain integration.
 work_done_short: >
-  Built a complete on-chain chess game with Dojo contracts, a React frontend, Cartridge
-  Controller integration, and spectator staking mechanics.
+  Built a **complete on-chain chess game** with Dojo contracts, a React frontend, **Cartridge
+  Controller integration**, and **spectator staking mechanics**.
 work_done_long: >
-  Developed a full chess game with a two-person team. Backend developer implemented Dojo
-  smart contracts for game logic, move validation, and spectator prediction staking.
-  Frontend developer built a React interface with Cartridge Controller integration,
+  Developed a full chess game with a two-person team. Backend developer implemented **Dojo
+  smart contracts** for game logic, move validation, and **spectator prediction staking**.
+  Frontend developer built a React interface with **Cartridge Controller integration**,
   real-time game state rendering, and PvP/PvC mode support.
 repo_url: "https://github.com/morelucks/stark-chess"
 demo_url: null

--- a/gj7/stark-path.md
+++ b/gj7/stark-path.md
@@ -3,22 +3,22 @@ id: "stark-path"
 emoji: "🧠"
 title: "Stark-Path"
 summary_short: >
-  On-chain memory puzzle game where players navigate paths by recalling sequences.
+  **On-chain memory puzzle game** where players navigate paths by **recalling sequences**.
   Built with Dojo Engine on Starknet, combining traditional memory gameplay with
-  blockchain verification.
+  **blockchain verification**.
 summary_long: >
-  StarkPath is an on-chain memory game built with Dojo on Starknet. Players recall and
+  StarkPath is an **on-chain memory game** built with Dojo on Starknet. Players recall and
   reproduce path sequences in a blockchain-verified environment. The game stores player
   state using a single Dojo model and processes moves through a dedicated system contract.
-  A frontend SDK integration provides a responsive browser interface. The repository is
-  largely pre-existing work with only 2% of commits made during the jam.
+  A **frontend SDK integration** provides a responsive browser interface. The repository is
+  largely **pre-existing work** with only 2% of commits made during the jam.
 work_done_short: >
-  Integrated a Dojo smart contract with one model and one system into an existing memory
-  game codebase, plus a frontend SDK connection.
+  Integrated a **Dojo smart contract** with one model and one system into an existing memory
+  game codebase, plus a **frontend SDK connection**.
 work_done_long: >
-  Built a single Dojo model for player puzzle state and one system contract for move logic.
-  Connected the frontend to the Dojo backend via the SDK. The repository is largely
-  pre-existing with only 1 of 37 total commits attributable to the jam period.
+  Built a **single Dojo model** for player puzzle state and one system contract for move logic.
+  Connected the frontend to the Dojo backend via the **SDK**. The repository is largely
+  **pre-existing** with only 1 of 37 total commits attributable to the jam period.
 repo_url: "https://github.com/dimka90/stark-path"
 demo_url: null
 video_url: "https://youtu.be/-7fKWNWSPfg"

--- a/gj7/starkcity.md
+++ b/gj7/starkcity.md
@@ -3,23 +3,23 @@ id: "starkcity"
 emoji: "🏘️"
 title: "Starkcity"
 summary_short: >
-  On-chain Monopoly-style board game where players buy, trade, and build properties
-  represented as ERC-1155 tokens. Every dice roll, property trade, and rent payment is
-  verified on Starknet via Dojo.
+  **On-chain Monopoly-style board game** where players buy, trade, and build properties
+  represented as **ERC-1155 tokens**. Every dice roll, property trade, and rent payment is
+  **verified on Starknet** via Dojo.
 summary_long: >
-  Starkcity is a multiplayer Monopoly-inspired game built on Starknet using Dojo. Players
-  roll dice, purchase properties minted as ERC-1155 tokens, collect rent, and develop
+  Starkcity is a **multiplayer Monopoly-inspired game** built on Starknet using Dojo. Players
+  roll dice, purchase properties minted as **ERC-1155 tokens**, collect rent, and develop
   holdings, all verified on-chain. The Dojo backend uses 1 model, 1 system, and 1 event.
-  A frontend SDK connects the browser client to the chain. Deployed live on Vercel, though
+  A **frontend SDK** connects the browser client to the chain. **Deployed live on Vercel**, though
   only 5 of 59 commits (8%) fall within the jam window.
 work_done_short: >
-  Built a Dojo contract layer with one model, one system, and one event, plus a
-  live-deployed frontend connected via the SDK.
+  Built a **Dojo contract layer** with one model, one system, and one event, plus a
+  **live-deployed frontend** connected via the SDK.
 work_done_long: >
-  Implemented a Dojo model for board and player state, a system contract for turn
+  Implemented a **Dojo model** for board and player state, a system contract for turn
   processing and property transactions, and an event for real-time updates. Connected a
-  browser frontend through the Dojo SDK and deployed it to Vercel. With 5 of 59 total
-  commits (8%) during the jam, the majority of the codebase predates the event.
+  browser frontend through the **Dojo SDK** and deployed it to Vercel. With 5 of 59 total
+  commits (8%) during the jam, the **majority of the codebase predates** the event.
 repo_url: "https://github.com/zarah-s/stark-city"
 demo_url: "https://starkcity.vercel.app"
 video_url: null

--- a/gj7/survivor-valhalla.md
+++ b/gj7/survivor-valhalla.md
@@ -3,23 +3,23 @@ id: "survivor-valhalla"
 emoji: "⚔️"
 title: "Survivor Valhalla"
 summary_short: >
-  Composable auto-battler built on the Loot Survivor ecosystem. Players create beast
-  bases and attack enemy bases using survivor lineups, extending ERC-721 NFTs from Loot
+  **Composable auto-battler** built on the **Loot Survivor ecosystem**. Players create beast
+  bases and attack enemy bases using survivor lineups, extending **ERC-721 NFTs** from Loot
   Survivor with new on-chain gameplay.
 summary_long: >
-  Survivor Valhalla is an auto-battler that composes on top of the Loot Survivor ecosystem,
+  Survivor Valhalla is an **auto-battler** that composes on top of the **Loot Survivor ecosystem**,
   giving existing ERC-721 beast and survivor NFTs new strategic utility. Players assemble
   beast bases for defense and survivor lineups for offense, then launch attacks resolved
   entirely on-chain. The Dojo backend features 1 model for game state, 3 system contracts,
-  and 2 events for combat outcomes. A frontend SDK connects to a live deployment on Netlify.
+  and 2 events for combat outcomes. A **frontend SDK** connects to a **live deployment on Netlify**.
   All commits were made during the jam.
 work_done_short: >
-  Built a full auto-battler from scratch with 1 model, 3 systems, 2 events, and a
-  live-deployed frontend during the jam.
+  Built a **full auto-battler from scratch** with 1 model, 3 systems, 2 events, and a
+  **live-deployed frontend** during the jam.
 work_done_long: >
-  Created a Dojo model for beast base and survivor lineup state, 3 system contracts for
+  Created a **Dojo model** for beast base and survivor lineup state, **3 system contracts** for
   base creation, attack resolution, and lineup management, and 2 events for combat results.
-  Integrated the frontend via the Dojo SDK and deployed live on Netlify.
+  Integrated the frontend via the Dojo SDK and **deployed live on Netlify**.
 repo_url: "https://github.com/Eikix/survivor-valhalla"
 demo_url: "https://survivor-valhalla.netlify.app/"
 video_url: null

--- a/gj7/take-your-shot.md
+++ b/gj7/take-your-shot.md
@@ -3,24 +3,24 @@ id: "take-your-shot"
 emoji: "🔫"
 title: "Take Your Shot"
 summary_short: >
-  3D first-person shooter set in procedurally generated mazes, connected to a Vesu
-  liquidation bot. Players fight increasingly faster enemies, and upon death their kill
+  **3D first-person shooter** set in **procedurally generated mazes**, connected to a **Vesu
+  liquidation bot**. Players fight increasingly faster enemies, and upon death their kill
   count translates into liquidation earnings assigned to their wallet.
 summary_long: >
-  Take Your Shot is a browser-based 3D FPS where players navigate randomly generated mazes
-  and fight enemies that speed up over time. The game integrates with a Vesu liquidation bot
+  Take Your Shot is a **browser-based 3D FPS** where players navigate randomly generated mazes
+  and fight enemies that speed up over time. The game integrates with a **Vesu liquidation bot**
   on Starknet. When the player dies, their kill count determines how many liquidation
   earnings are assigned to their wallet. The Dojo backend uses 1 model and 1 system. A
-  frontend SDK provides the browser interface with keyboard controls. All commits were made
+  **frontend SDK** provides the browser interface with keyboard controls. All commits were made
   during the jam.
 work_done_short: >
-  Built a complete 3D FPS with procedural maze generation, enemy AI, and Vesu liquidation
-  bot integration from scratch during the jam.
+  Built a **complete 3D FPS** with **procedural maze generation**, enemy AI, and **Vesu liquidation
+  bot integration** from scratch during the jam.
 work_done_long: >
-  Developed a 3D first-person shooter with procedural maze generation, progressive enemy
+  Developed a **3D first-person shooter** with procedural maze generation, progressive enemy
   difficulty, and keyboard controls. Implemented 1 Dojo model for player state and 1 system
-  for game logic. Integrated a Vesu liquidation bot that converts kill counts to on-chain
-  earnings. Connected the frontend via the Dojo SDK.
+  for game logic. Integrated a **Vesu liquidation bot** that converts kill counts to on-chain
+  earnings. Connected the frontend via the **Dojo SDK**.
 repo_url: "https://github.com/jilt/take-your-shot"
 demo_url: null
 video_url: null

--- a/gj7/tomie-games.md
+++ b/gj7/tomie-games.md
@@ -3,24 +3,24 @@ id: "tomie-games"
 emoji: "🎭"
 title: "Tomie Games"
 summary_short: >
-  Narrative-driven on-chain Rock, Paper, Scissors duel on Starknet with Dojo. Players face
-  off against Tomie in a psychological battle with voice-acted dialogue, expressive
-  character animations, and a life-based elimination system.
+  **Narrative-driven** on-chain **Rock, Paper, Scissors** duel on Starknet with Dojo. Players face
+  off against Tomie in a psychological battle with **voice-acted dialogue**, expressive
+  character animations, and a **life-based elimination system**.
 summary_long: >
-  Tomie Games reimagines Rock, Paper, Scissors as a cinematic horror experience inspired by
+  Tomie Games reimagines Rock, Paper, Scissors as a **cinematic horror experience** inspired by
   Junji Ito. Players connect via Cartridge Controller and engage in a best-of-five duel
   against Tomie, whose expressions and dialogue shift dynamically based on match outcomes.
-  The game features a typewriter text system, voice-acted lines, and cinematic transitions.
+  The game features a **typewriter text system**, voice-acted lines, and cinematic transitions.
   Built with React, TypeScript, and Vite, using Dojo's on-chain architecture to store every
-  action as verifiable game state, with a custom HTML5 audio sync manager.
+  action as verifiable game state, with a custom **HTML5 audio sync manager**.
 work_done_short: >
-  Built a complete narrative Rock-Paper-Scissors game from scratch including on-chain game
-  logic, voice-acted dialogue system, and animated character reactions.
+  Built a **complete narrative Rock-Paper-Scissors game from scratch** including on-chain game
+  logic, **voice-acted dialogue system**, and animated character reactions.
 work_done_long: >
-  Developed a Dojo contract layer with game model and action system for on-chain RPS duels.
-  Created a React/TypeScript frontend with typewriter text animation, dynamic character
-  expressions, custom HTML5 audio synchronization for voice acting, life-tracking UI, and
-  cinematic fade transitions. Deployed live on Vercel with Cartridge Controller.
+  Developed a **Dojo contract layer** with game model and action system for on-chain RPS duels.
+  Created a React/TypeScript frontend with **typewriter text animation**, dynamic character
+  expressions, **custom HTML5 audio synchronization** for voice acting, life-tracking UI, and
+  cinematic fade transitions. **Deployed live on Vercel** with Cartridge Controller.
 repo_url: "https://github.com/dubzn/tomie-games"
 demo_url: "https://tomie-games.vercel.app/"
 video_url: "https://www.youtube.com/watch?v=bah7IStmMq8"

--- a/gj7/tycoon.md
+++ b/gj7/tycoon.md
@@ -3,21 +3,21 @@ id: "tycoon"
 emoji: "🏠"
 title: "Tycoon"
 summary_short: >
-  Monopoly-inspired on-chain strategy game on Starknet. Players buy properties, collect
-  rent, and compete in a fully transparent economy where all game logic runs through smart
+  **Monopoly-inspired on-chain strategy game** on Starknet. Players buy properties, collect
+  rent, and compete in a **fully transparent economy** where all game logic runs through smart
   contracts.
 summary_long: >
-  Tycoon brings the Monopoly board game formula on-chain using Starknet. Players roll dice,
+  Tycoon brings the **Monopoly board game formula** on-chain using Starknet. Players roll dice,
   purchase properties, pay rent, and manage their economy with every action verified through
-  smart contracts. However, the repository is a large pre-existing project with 1244 commits
+  **smart contracts**. However, the repository is a large **pre-existing project** with 1244 commits
   and no Dojo framework markers were detected. The submission appears to be a previously
   developed project rather than work created during the game jam.
 work_done_short: >
-  Submitted a pre-existing Monopoly-style game. No Dojo contracts or jam-period development
+  Submitted a **pre-existing** Monopoly-style game. **No Dojo contracts** or jam-period development
   activity was detected in the repository.
 work_done_long: >
-  The repository contains 1244 commits with none attributable to the jam period. No Dojo
-  models, systems, or events were found. The frontend does not use the Dojo SDK. The project
+  The repository contains **1244 commits** with none attributable to the jam period. **No Dojo
+  models, systems, or events** were found. The frontend does not use the Dojo SDK. The project
   appears to be a fully developed game submitted without Dojo integration or jam-specific
   development.
 repo_url: "https://github.com/aji70/Tycoon"

--- a/gj7/witch-craft.md
+++ b/gj7/witch-craft.md
@@ -3,25 +3,25 @@ id: "witch-craft"
 emoji: "🧙"
 title: "Witchcraft"
 summary_short: >
-  Blockchain-first survival game where players explore mystical biomes, gather ingredients,
-  brew potions, and fight hostile NPCs. Features a day/night cycle with daytime foraging
+  **Blockchain-first survival game** where players explore mystical biomes, gather ingredients,
+  brew potions, and fight hostile NPCs. Features a **day/night cycle** with daytime foraging
   and nighttime potion selling.
 summary_long: >
-  Witchcraft is a fully on-chain survival game built on Starknet with Dojo. Players explore
+  Witchcraft is a **fully on-chain survival game** built on Starknet with Dojo. Players explore
   six biomes collecting ingredients while fending off hostile NPCs. During the day players
-  forage and fight; at night they brew and sell potions to earn gold and faction reputation.
+  forage and fight; at night they **brew and sell potions** to earn gold and faction reputation.
   The game implements 14 Dojo systems covering spawning, movement, foraging, brewing, combat,
   selling, faction reputation, progression, economy, zone management, and resource
-  regeneration. The React frontend features sprite animations, day/night backgrounds, and
-  real-time blockchain state synchronization.
+  regeneration. The React frontend features **sprite animations**, day/night backgrounds, and
+  **real-time blockchain state synchronization**.
 work_done_short: >
-  Built a complete survival game with 14 Dojo systems, six explorable biomes, real-time
-  combat, a brewing economy, and a React frontend with animated sprites.
+  Built a **complete survival game** with **14 Dojo systems**, six explorable biomes, real-time
+  combat, a brewing economy, and a **React frontend** with animated sprites.
 work_done_long: >
-  Developed 14 on-chain Dojo systems handling player spawning, movement, foraging, brewing,
+  Developed **14 on-chain Dojo systems** handling player spawning, movement, foraging, brewing,
   combat, selling, faction reputation, progression, economy, zone management, and resource
-  regeneration. Created a React frontend with 2D sprite-based exploration, NPC combat,
-  day/night transitions, an inventory and recipe system, and a shop interface.
+  regeneration. Created a React frontend with **2D sprite-based exploration**, NPC combat,
+  **day/night transitions**, an inventory and recipe system, and a shop interface.
 repo_url: "https://github.com/krishnan74/witchcraft"
 demo_url: "http://witchcraft-eight.vercel.app/"
 video_url: "https://drive.google.com/file/d/1ZSpFxMKiPKTqp2P5k09DwYTuYMvSgbuv/view?usp=sharing"

--- a/gj7/witch-or-treat.md
+++ b/gj7/witch-or-treat.md
@@ -3,23 +3,23 @@ id: "witch-or-treat"
 emoji: "🎃"
 title: "Witch or Treat"
 summary_short: >
-  On-chain Halloween mini-game built with Dojo where players ring a doorbell to collect
-  treats, brew magical potions with different effects, and risk being cursed by the Witch.
+  **On-chain Halloween mini-game** built with Dojo where players ring a doorbell to collect
+  treats, **brew magical potions** with different effects, and risk being **cursed by the Witch**.
 summary_long: >
-  Witch or Treat is a Halloween-themed on-chain mini-game on Starknet using Dojo and Cairo
+  Witch or Treat is a **Halloween-themed on-chain mini-game** on Starknet using Dojo and Cairo
   smart contracts. Players ring a doorbell to randomly collect treats, then brew three types
-  of potions with different costs and strategic effects. Drinking potions activates buffs,
-  but the Witch can curse players at any time. The game uses Dojo's on-chain architecture
+  of potions with different costs and **strategic effects**. Drinking potions activates buffs,
+  but the **Witch can curse players** at any time. The game uses Dojo's on-chain architecture
   with Torii for real-time state synchronization. The repository is a fork of the game-jams
   repo with game code in a subdirectory.
 work_done_short: >
-  Built a Halloween-themed treat-collecting and potion-brewing mini-game using Dojo and
-  Cairo contracts with a JavaScript frontend.
+  Built a **Halloween-themed** treat-collecting and **potion-brewing mini-game** using Dojo and
+  **Cairo contracts** with a JavaScript frontend.
 work_done_long: >
-  Developed an on-chain mini-game within the game-jams repository fork, implementing
-  doorbell interaction for random treat collection, a potion brewing system with three
-  recipe types, potion activation effects, and a curse mechanic. Built Cairo smart contracts
-  with Torii indexing for real-time state sync. Created a JavaScript/HTML/CSS frontend.
+  Developed an **on-chain mini-game** within the game-jams repository fork, implementing
+  doorbell interaction for random treat collection, a **potion brewing system** with three
+  recipe types, potion activation effects, and a curse mechanic. Built **Cairo smart contracts**
+  with **Torii indexing** for real-time state sync. Created a JavaScript/HTML/CSS frontend.
 repo_url: "https://github.com/Akaninyang/game-jams/tree/aa6dca3d11953c23151fa8981b123385ed79ef26/games/witch-or-treat"
 demo_url: null
 video_url: null


### PR DESCRIPTION
Add markdown bolding to summary_short, summary_long, work_done_short, and work_done_long fields across all game jam submission files (gj4, gj5, gj6, gj7) per the Daimyo ENRICHMENT.md specification.

Each field now highlights 2–4 key phrases for judges skimming quickly: game genre/type, core mechanics, technical features, and deployment status.

58 submission files updated with strategic bolding to improve readability and visual hierarchy in the Daimyo judging interface.