### PR TITLE
fix: auto-trigger submission screening on PR title patterns

### DIFF
--- a/.github/workflows/submission-screen.yml
+++ b/.github/workflows/submission-screen.yml
@@ -5,20 +5,44 @@ on:
     types: [opened, synchronize, reopened]
     paths:
       - 'gj*/*.md'
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to screen'
+        required: true
+        type: string
 
 jobs:
   screen:
     runs-on: ubuntu-latest
-    if: contains(github.event.pull_request.title, '[Project Submission]')
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      contains(github.event.pull_request.title, 'Submission') ||
+      contains(github.event.pull_request.title, 'submission')
     permissions:
       contents: read
       pull-requests: write
 
     steps:
+      - name: Get PR info
+        id: pr
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            PR_NUMBER="${{ github.event.inputs.pr_number }}"
+            HEAD_SHA=$(gh pr view "$PR_NUMBER" --json headRefOid --jq .headRefOid)
+          else
+            PR_NUMBER="${{ github.event.pull_request.number }}"
+            HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+          fi
+          echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+          echo "head_sha=$HEAD_SHA" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Checkout PR head
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ steps.pr.outputs.head_sha }}
 
       - name: Screen submission
         uses: anthropics/claude-code-action@beta
@@ -33,5 +57,5 @@ jobs:
             Use `git show origin/main:spec/SCREENING.md` to read it, rather than the copy on the PR branch.
 
             Environment:
-            - PR number: ${{ github.event.pull_request.number }}
+            - PR number: ${{ steps.pr.outputs.number }}
             - Repository: ${{ github.repository }}


### PR DESCRIPTION
Fixes PR #270 where screening didn't trigger due to a title pattern mismatch.

**Changes:**
- Auto-trigger on PRs containing "Submission" (case-insensitive) instead of only exact `[Project Submission]` match
- Add `workflow_dispatch` trigger to manually screen PRs that don't auto-match (e.g., `[Project Registration]`)
- Extract PR info (number and head SHA) to support both event types

**Why this matters:**
GJ8 uses `[Project Registration]` titles, which weren't matching the workflow's hardcoded check for `[Project Submission]`. Now users can manually trigger screening on registration PRs via the Actions tab.

🤖 Generated with Claude Code