### PR TITLE
fix: resolve submission screening workflow failures

### DIFF
--- a/.github/workflows/submission-screen.yml
+++ b/.github/workflows/submission-screen.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             PR_NUMBER="${{ github.event.inputs.pr_number }}"
-            HEAD_SHA=$(gh pr view "$PR_NUMBER" --json headRefOid --jq .headRefOid)
+            HEAD_SHA=$(gh pr view "$PR_NUMBER" --repo "${{ github.repository }}" --json headRefOid --jq .headRefOid)
           else
             PR_NUMBER="${{ github.event.pull_request.number }}"
             HEAD_SHA="${{ github.event.pull_request.head.sha }}"
@@ -43,8 +43,13 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ steps.pr.outputs.head_sha }}
+          fetch-depth: 0
+
+      - name: Fetch main branch
+        run: git fetch origin main
 
       - name: Screen submission
+        timeout-minutes: 30
         uses: anthropics/claude-code-action@beta
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
Fixes the submission screening workflow that failed when triggered manually via workflow_dispatch.

**Changes:**
- Add `--repo` flag to `gh pr view` command to query PR info without a local git repo (required for workflow_dispatch trigger)
- Add `fetch-depth: 0` and explicit `git fetch origin main` to ensure screening agent can read `spec/SCREENING.md` from the main branch
- Add `timeout-minutes: 30` to prevent the screening step from running indefinitely

The workflow now properly handles both pull_request (automatic) and workflow_dispatch (manual) triggers.

🤖 Generated with Claude Code