### PR TITLE
fix: set claude-code-action mode to agent for workflow_dispatch

### DIFF
--- a/.github/workflows/submission-screen.yml
+++ b/.github/workflows/submission-screen.yml
@@ -54,6 +54,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          mode: agent
           allowed_tools: "Bash,Read,Grep,Glob,WebFetch"
           direct_prompt: |
             You are screening a Dojo Game Jam submission PR.


### PR DESCRIPTION
## Summary
- Set `mode: agent` on the `claude-code-action` step so `workflow_dispatch` triggers work. Tag mode (the default) rejects non-PR events.

## Test plan
- [ ] Manually trigger the screening workflow via workflow_dispatch for PR #270

🤖 Generated with [Claude Code](https://claude.com/claude-code)