### PR TITLE
[Submission]: Hex'd

### DIFF
--- a/gj8/hexd.md
+++ b/gj8/hexd.md
@@ -10,7 +10,7 @@ All game logic, state, and randomness live fully onchain. The frontend is a play
 
 **Jam scope — Embeddable Game Standard (EGS) integration:**
 
-Hex'd existed before Game Jam VIII. The scope of this submission is the implementation of the [Embeddable Game Standard](https://github.com/FemiOje/hexed/tree/embeddable), which turns every game session into a portable, discoverable ERC-721 token on Starknet. This involved:
+The scope of this submission is the implementation of the [Embeddable Game Standard](https://github.com/FemiOje/hexed/tree/embeddable), which turns every game session into a portable, discoverable ERC-721 token on Starknet. This involved:
 
 - `game_token_systems` contract — ERC-721 minting per session via EGS `MinigameComponent`
 - Token ownership verification in `spawn()` and `move()` via EGS hooks


### PR DESCRIPTION
## Summary

Hex'd is a fully onchain asynchronous battle royale with fog of war, built with Cairo and Dojo on Starknet.

**Jam scope:** The scope of this submission is the implementation of the **Embeddable Game Standard (EGS)**, which turns every game session into a portable, discoverable ERC-721 token. The full implementation is on the [`embeddable` branch](https://github.com/FemiOje/hexed/tree/embeddable).

### What was built during the jam

- `game_token_systems` contract — ERC-721 minting per game session via EGS `MinigameComponent`
- Token ownership verification in `spawn()` and `move()` via EGS hooks
- Renderer contract implementing `IMinigameDetails` for external platform display
- Frontend token discovery via Denshokan SDK with live game state enrichment
- Automatic onchain score registration on player death
- "My Games" UI for browsing active/dead/unspawned tokens and viewing them on external portfolios

### Links

- **Source code:** https://github.com/FemiOje/hexed
- **EGS branch:** https://github.com/FemiOje/hexed/tree/embeddable
- **Live demo:** https://hexed-silk.vercel.app/
- **Gameplay video:** https://youtu.be/cZOFKLjaeSw