### PR TITLE
Fix submission workflows to support fork PRs

### DIFF
--- a/.github/workflows/submission-enrich.yml
+++ b/.github/workflows/submission-enrich.yml
@@ -1,21 +1,24 @@
 name: Enrich Submissions
 
 on:
-  push:
-    branches: [main]
+  pull_request_target:
+    types: [closed]
     paths:
       - 'gj*/*.md'
 
 jobs:
   enrich:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
     permissions:
       contents: write
+      pull-requests: read
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          ref: main
           fetch-depth: 2
 
       - name: Find new submissions

--- a/.github/workflows/submission-screen.yml
+++ b/.github/workflows/submission-screen.yml
@@ -1,7 +1,7 @@
 name: Submission Screening
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened]
     paths:
       - 'gj*/*.md'
@@ -15,10 +15,7 @@ on:
 jobs:
   screen:
     runs-on: ubuntu-latest
-    if: >-
-      github.event_name == 'workflow_dispatch' ||
-      contains(github.event.pull_request.title, 'Submission') ||
-      contains(github.event.pull_request.title, 'submission')
+    # paths filter on pull_request_target already limits to gj*/*.md changes
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
## Summary
Fix permission errors in submission screening workflow and update enrichment workflow to support automated execution.

**screening**: Switch from `pull_request` to `pull_request_target` to fix write permission errors when screening fork PRs. External contributors have read-only access; `pull_request_target` runs in the base repo context with proper permissions. Removed overly strict title filtering since the `paths` filter already limits to submission files.

**enrichment**: Change trigger from `push` to `pull_request_target closed` with merged check, since `claude-code-action` doesn't support push events. This enables the workflow to automatically enrich submissions when PRs are merged.

## Test plan
- Fork PRs with submission files should now trigger screening without permission errors
- PR merges should automatically trigger enrichment workflow