### PR TITLE
enrich: Add onchain/offchain gameplay tags to gj7

### DIFF
--- a/gj7/butu.md
+++ b/gj7/butu.md
@@ -34,6 +34,7 @@ metrics:
   client_sdk: "dojo.js"
   jam_commits_pct: 100
   playability: "Live"
+  gameplay: "Offchain"
 ---
 
 # Butu

--- a/gj7/chance-master.md
+++ b/gj7/chance-master.md
@@ -36,6 +36,7 @@ metrics:
   client_sdk: "dojo.js"
   jam_commits_pct: 100
   playability: "Video"
+  gameplay: "Onchain"
 ---
 # Chance Master ♟️🎲
 

--- a/gj7/charon.md
+++ b/gj7/charon.md
@@ -34,6 +34,7 @@ metrics:
   client_sdk: "dojo.js"
   jam_commits_pct: 100
   playability: "Live"
+  gameplay: "Onchain"
 ---
 
 

--- a/gj7/destiny.md
+++ b/gj7/destiny.md
@@ -35,6 +35,7 @@ metrics:
   client_sdk: "dojo.js"
   jam_commits_pct: 100
   playability: "Live"
+  gameplay: "Onchain"
 ---
 # DESTINY
 

--- a/gj7/duels-x.md
+++ b/gj7/duels-x.md
@@ -35,6 +35,7 @@ metrics:
   client_sdk: "None"
   jam_commits_pct: 100
   playability: "Live"
+  gameplay: "Onchain"
 ---
 # Duels X
 

--- a/gj7/feral-forge.md
+++ b/gj7/feral-forge.md
@@ -35,6 +35,7 @@ metrics:
   client_sdk: "dojo.js"
   jam_commits_pct: 62
   playability: "Live"
+  gameplay: "Offchain"
 ---
 # Feral Forge
 

--- a/gj7/ghost-grid.md
+++ b/gj7/ghost-grid.md
@@ -35,6 +35,7 @@ metrics:
   client_sdk: "None"
   jam_commits_pct: 100
   playability: "Live"
+  gameplay: "Offchain"
 ---
 # Ghost Grid
 

--- a/gj7/grim-block.md
+++ b/gj7/grim-block.md
@@ -36,6 +36,7 @@ metrics:
   client_sdk: "dojo.js"
   jam_commits_pct: 100
   playability: "Live"
+  gameplay: "Onchain"
 ---
 # Grim Block
 

--- a/gj7/harvest-heist.md
+++ b/gj7/harvest-heist.md
@@ -37,6 +37,7 @@ metrics:
   client_sdk: "dojo.js"
   jam_commits_pct: 100
   playability: "Live"
+  gameplay: "Offchain"
 ---
 # Harvest Heist
 

--- a/gj7/kanoodle-fusion.md
+++ b/gj7/kanoodle-fusion.md
@@ -37,6 +37,7 @@ metrics:
   client_sdk: "None"
   jam_commits_pct: 100
   playability: "Live"
+  gameplay: "Offchain"
 ---
 # Kanoodle Fusion
 

--- a/gj7/mastermind.md
+++ b/gj7/mastermind.md
@@ -36,6 +36,7 @@ metrics:
   client_sdk: "dojo.js"
   jam_commits_pct: 100
   playability: "None"
+  gameplay: "Onchain"
 ---
 # ZK Word Mastermind
 

--- a/gj7/onchain-excavator.md
+++ b/gj7/onchain-excavator.md
@@ -35,6 +35,7 @@ metrics:
   client_sdk: "dojo.js"
   jam_commits_pct: 52
   playability: "Live"
+  gameplay: "Offchain"
 ---
 # Onchain Excavator
 

--- a/gj7/scard.md
+++ b/gj7/scard.md
@@ -36,6 +36,7 @@ metrics:
   client_sdk: "dojo.js"
   jam_commits_pct: 95
   playability: "Live"
+  gameplay: "Onchain"
 ---
 # Scar'd
 

--- a/gj7/simula.md
+++ b/gj7/simula.md
@@ -34,6 +34,7 @@ metrics:
   client_sdk: "dojo.js"
   jam_commits_pct: 8
   playability: "Live"
+  gameplay: "Offchain"
 ---
 # Simula
 

--- a/gj7/stark-chess.md
+++ b/gj7/stark-chess.md
@@ -35,6 +35,7 @@ metrics:
   client_sdk: "None"
   jam_commits_pct: 0
   playability: "Video"
+  gameplay: "Onchain"
   repo_unavailable: true
 ---
 ## Project Name

--- a/gj7/stark-path.md
+++ b/gj7/stark-path.md
@@ -33,6 +33,7 @@ metrics:
   client_sdk: "dojo.js"
   jam_commits_pct: 2
   playability: "Video"
+  gameplay: "Offchain"
 ---
 # Project Name
 Stark-Path

--- a/gj7/starkcity.md
+++ b/gj7/starkcity.md
@@ -34,6 +34,7 @@ metrics:
   client_sdk: "dojo.js"
   jam_commits_pct: 8
   playability: "Live"
+  gameplay: "Onchain"
 ---
 # Starkcity
 

--- a/gj7/survivor-valhalla.md
+++ b/gj7/survivor-valhalla.md
@@ -35,6 +35,7 @@ metrics:
   client_sdk: "dojo.js"
   jam_commits_pct: 100
   playability: "Live"
+  gameplay: "Onchain"
 ---
 # Survivor Valhalla
 

--- a/gj7/take-your-shot.md
+++ b/gj7/take-your-shot.md
@@ -35,6 +35,7 @@ metrics:
   client_sdk: "dojo.js"
   jam_commits_pct: 100
   playability: "None"
+  gameplay: "Offchain"
 ---
 # Take Your Shot
 

--- a/gj7/tomie-games.md
+++ b/gj7/tomie-games.md
@@ -35,6 +35,7 @@ metrics:
   client_sdk: "dojo.js"
   jam_commits_pct: 100
   playability: "Live"
+  gameplay: "Onchain"
 ---
 # TOMIE GAMES
 

--- a/gj7/tycoon.md
+++ b/gj7/tycoon.md
@@ -34,6 +34,7 @@ metrics:
   client_sdk: "None"
   jam_commits_pct: 0
   playability: "Live"
+  gameplay: "Offchain"
 ---
 # Game Jam Submission Template
 

--- a/gj7/witch-craft.md
+++ b/gj7/witch-craft.md
@@ -37,6 +37,7 @@ metrics:
   client_sdk: "dojo.js"
   jam_commits_pct: 95
   playability: "Live"
+  gameplay: "Onchain"
 ---
 # Witchcraft
 **Submission Track**  

--- a/gj7/witch-or-treat.md
+++ b/gj7/witch-or-treat.md
@@ -34,6 +34,7 @@ metrics:
   client_sdk: "None"
   jam_commits_pct: 0
   playability: "None"
+  gameplay: "Offchain"
 ---
 # 🎃 Witch or Treat
 


### PR DESCRIPTION
Classify each gj7 game entry based on whether core gameplay logic runs onchain (smart contracts handle moves/combat/turns) or offchain (client-side with blockchain for persistence).

**Summary:** 12 Onchain, 11 Offchain entries across all 23 gj7 submissions.

Games with **Onchain** gameplay: chance-master, charon, destiny, duels-x, grim-block, mastermind, scard, stark-chess, starkcity, survivor-valhalla, tomie-games, witch-craft

Games with **Offchain** gameplay: butu, feral-forge, ghost-grid, harvest-heist, kanoodle-fusion, onchain-excavator, simula, stark-path, take-your-shot, tycoon, witch-or-treat