### PR TITLE
fix: Correct Blokaz Dojo metrics

### DIFF
--- a/gj8/blokaz.md
+++ b/gj8/blokaz.md
@@ -36,9 +36,9 @@ team:
 metrics:
   classification: "Whole Game"
   team_size: 3
-  dojo_models: 6
-  dojo_systems: 1
-  dojo_events: 3
+  dojo_models: 0
+  dojo_systems: 0
+  dojo_events: 0
   client_sdk: "None"
   jam_commits_pct: 100
   gameplay: "Onchain"


### PR DESCRIPTION
Blokaz uses Embeddable Game Standard (EGS), not Dojo. Updated dojo_models, dojo_systems, and dojo_events metrics from 6/1/3 to 0/0/0 to accurately reflect the absence of #[dojo::*] decorators in the codebase.

See investigation: Blokaz was flagged during screening for not using Dojo, but the enrichment agent miscounted EGS components as Dojo artifacts.

🤖 Generated with Claude Code